### PR TITLE
Picture number limit on requests in backend

### DIFF
--- a/Code/Server/models/ai.go
+++ b/Code/Server/models/ai.go
@@ -1,9 +1,9 @@
 package models
 
 type SummarizeRequest struct {
-	Type     string   `binding:"required,oneof=room furniture"        json:"type"`
-	Id       string   `binding:"required"                             json:"id"`
-	Pictures []string `binding:"required,min=1,dive,required,datauri" json:"pictures"`
+	Type     string   `binding:"required,oneof=room furniture"               json:"type"`
+	Id       string   `binding:"required"                                    json:"id"`
+	Pictures []string `binding:"required,min=1,max=10,dive,required,datauri" json:"pictures"`
 }
 
 type SummarizeResponse struct {
@@ -13,9 +13,9 @@ type SummarizeResponse struct {
 }
 
 type CompareRequest struct {
-	Type     string   `binding:"required,oneof=room furniture"        json:"type"`
-	Id       string   `binding:"required"                             json:"id"`
-	Pictures []string `binding:"required,min=1,dive,required,datauri" json:"pictures"`
+	Type     string   `binding:"required,oneof=room furniture"               json:"type"`
+	Id       string   `binding:"required"                                    json:"id"`
+	Pictures []string `binding:"required,min=1,max=10,dive,required,datauri" json:"pictures"`
 }
 
 type CompareResponse struct {

--- a/Code/Server/models/damage.go
+++ b/Code/Server/models/damage.go
@@ -5,10 +5,10 @@ import (
 )
 
 type DamageRequest struct {
-	Comment  string      `binding:"required"              json:"comment"`
-	Priority db.Priority `binding:"required,priority"     json:"priority"`
-	RoomID   string      `binding:"required"              json:"room_id"`
-	Pictures []string    `binding:"dive,required,datauri" json:"pictures"`
+	Comment  string      `binding:"required"                    json:"comment"`
+	Priority db.Priority `binding:"required,priority"           json:"priority"`
+	RoomID   string      `binding:"required"                    json:"room_id"`
+	Pictures []string    `binding:"max=5,dive,required,datauri" json:"pictures"`
 }
 
 func (r *DamageRequest) ToDbDamage() db.DamageModel {

--- a/Code/Server/models/inventoryReport.go
+++ b/Code/Server/models/inventoryReport.go
@@ -7,20 +7,20 @@ import (
 )
 
 type FurnitureStateRequest struct {
-	ID          string         `binding:"required"                             json:"id"`
-	State       db.State       `binding:"required,state"                       json:"state"`
-	Cleanliness db.Cleanliness `binding:"required,cleanliness"                 json:"cleanliness"`
-	Note        string         `binding:"required"                             json:"note"`
-	Pictures    []string       `binding:"required,min=1,dive,required,datauri" json:"pictures"`
+	ID          string         `binding:"required"                                   json:"id"`
+	State       db.State       `binding:"required,state"                             json:"state"`
+	Cleanliness db.Cleanliness `binding:"required,cleanliness"                       json:"cleanliness"`
+	Note        string         `binding:"required"                                   json:"note"`
+	Pictures    []string       `binding:"required,min=1,max=5,dive,required,datauri" json:"pictures"`
 }
 
 type RoomStateRequest struct {
-	ID          string                  `binding:"required"                             json:"id"`
-	State       db.State                `binding:"required,state"                       json:"state"`
-	Cleanliness db.Cleanliness          `binding:"required,cleanliness"                 json:"cleanliness"`
-	Note        string                  `binding:"required"                             json:"note"`
-	Pictures    []string                `binding:"required,min=1,dive,required,datauri" json:"pictures"`
-	Furnitures  []FurnitureStateRequest `binding:"required,dive"                        json:"furnitures"`
+	ID          string                  `binding:"required"                                    json:"id"`
+	State       db.State                `binding:"required,state"                              json:"state"`
+	Cleanliness db.Cleanliness          `binding:"required,cleanliness"                        json:"cleanliness"`
+	Note        string                  `binding:"required"                                    json:"note"`
+	Pictures    []string                `binding:"required,min=1,max=10,dive,required,datauri" json:"pictures"`
+	Furnitures  []FurnitureStateRequest `binding:"required,dive"                               json:"furnitures"`
 }
 
 type InventoryReportRequest struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added maximum limits to the number of pictures allowed in various requests: up to 10 for summary and comparison requests, up to 5 for damage and furniture state requests, and up to 10 for room state requests.

- **Bug Fixes**
  - Improved validation to prevent submitting requests with too many pictures, ensuring better reliability and user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->