### PR TITLE
Automatic redirection to login fail when now token in app

### DIFF
--- a/Code/Mobile_iOS/Keyz/Sources/Components/ErrorNotificationView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Components/ErrorNotificationView.swift
@@ -1,0 +1,70 @@
+//
+//  ErrorNotificationView.swift
+//  Keyz
+//
+//  Created by Liebenguth Alessio on 17/06/2025.
+//
+
+
+//
+//  ErrorNotificationView.swift
+//  Keyz
+//
+//  Created by Liebenguth Alessio on 17/06/2025.
+//
+
+
+import SwiftUI
+
+struct ErrorNotificationView: View {
+    let message: String
+    @State private var isVisible = false
+    @State private var opacity: Double = 0.0
+    private let duration: TimeInterval = 5.0
+
+    var body: some View {
+        ZStack {
+            if isVisible {
+                VStack {
+                    Spacer()
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(.white)
+                            .padding(.leading, 10)
+                        Text(message)
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(.white)
+                            .padding(.vertical)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .background(Color("RedAlert"))
+                    .cornerRadius(12)
+                    .shadow(color: Color.black.opacity(0.2), radius: 4, x: 0, y: 2)
+                    .transition(.opacity)
+                    .opacity(opacity)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 20)
+                    .animation(.easeInOut(duration: 0.3), value: opacity)
+                }
+            }
+        }
+        .onAppear {
+            isVisible = true
+            opacity = 1.0
+            DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+                withAnimation {
+                    opacity = 0.0
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    isVisible = false
+                }
+            }
+        }
+    }
+}
+
+struct ErrorNotificationView_Previews: PreviewProvider {
+    static var previews: some View {
+        ErrorNotificationView(message: "Error fetching data")
+    }
+}

--- a/Code/Mobile_iOS/Keyz/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Code/Mobile_iOS/Keyz/Sources/Resources/fr.lproj/Localizable.strings
@@ -167,9 +167,10 @@
 "Archived" = "Archivée(s)";
 "Available_property" = "Disponible(s)";
 "Pending Invites" = "Invitation(s) en attente";
-"+%d more" = "+%d de plus";
 
 "Urgent_damage" = "Urgent(s)";
 "High_damage" = "Haut(s)";
 "Medium_damage" = "Moyen(s)";
 "Low_damage" = "Faible(s)";
+
+"No documents available" = "Aucun document disponible";

--- a/Code/Mobile_iOS/Keyz/Sources/TestImmotepApp.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/TestImmotepApp.swift
@@ -11,6 +11,7 @@ struct TestImmotepView: View {
     @AppStorage("isLoggedIn") var isLoggedIn: Bool = false
     @StateObject private var loginViewModel = LoginViewModel()
     @State private var propertyExample: Property = exampleDataProperty
+    @State var navigateToInventory: Bool = false
     @State private var mockProperty = Property(
         id: "cm7gijdee000ly7i82uq0qf35",
         ownerID: "owner123",
@@ -130,7 +131,6 @@ struct TestImmotepView: View {
     }
 
     private func inventoryRoomView() -> some View {
-        @State var navigateToInventory: Bool = false
         let viewModel = InventoryViewModel(
             property: propertyExample,
             localRooms: [

--- a/Code/Mobile_iOS/Keyz/Sources/Utils/AppDelegate.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Utils/AppDelegate.swift
@@ -27,11 +27,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
+        if !TokenStorage.keepMeSignedIn() {
+            UserDefaults.standard.set(false, forKey: "isLoggedIn")
+        }
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
         if !TokenStorage.keepMeSignedIn() {
-            self.isLoggedIn = false
+            UserDefaults.standard.set(false, forKey: "isLoggedIn")
         }
     }
 }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomEvaluationView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomEvaluationView.swift
@@ -61,10 +61,10 @@ struct InventoryRoomEvaluationView: View {
                         Spacer()
                     }
                     HStack {
-                        Picker("Select a status", selection: $inventoryViewModel.selectedStatus) {
-                            Text("Select room status").tag("Select room status")
+                        Picker("Select a status".localized(), selection: $inventoryViewModel.selectedStatus) {
+                            Text("Select room status".localized()).tag("Select room status")
                             ForEach(Array(stateMapping.values), id: \.self) { status in
-                                Text(status).tag(status)
+                                Text(status.localized()).tag(status)
                             }
                         }
                         .frame(maxWidth: .infinity)
@@ -88,7 +88,7 @@ struct InventoryRoomEvaluationView: View {
                             await validateReport()
                         }
                     }, label: {
-                        Text("Validate")
+                        Text("Validate".localized())
                             .padding()
                             .frame(maxWidth: .infinity)
                             .background(Color("LightBlue"))
@@ -104,7 +104,7 @@ struct InventoryRoomEvaluationView: View {
                             isLoading = false
                         }
                     }, label: {
-                        Text("Send Room Report")
+                        Text("Send Room Report".localized())
                             .padding()
                             .frame(maxWidth: .infinity)
                             .background(Color("LightBlue"))
@@ -178,19 +178,19 @@ struct InventoryRoomEvaluationView: View {
         } catch let error as NSError {
             switch error.code {
             case 404:
-                errorMessage = "Property or lease not found. Please check the property details."
+                errorMessage = "Property or lease not found. Please check the property details.".localized()
             case 403:
-                errorMessage = "You do not have permission to access this property."
+                errorMessage = "You do not have permission to access this property.".localized()
             case 400:
                 if error.localizedDescription.contains("datauri") {
-                    errorMessage = "Invalid image format. Please ensure all images are valid JPEGs."
+                    errorMessage = "Invalid image format. Please ensure all images are valid JPEGs.".localized()
                 } else {
                     errorMessage = "Invalid request: \(error.localizedDescription)"
                 }
             case 0 where error.localizedDescription.contains("No active lease found"):
-                errorMessage = "No active lease found for this property."
+                errorMessage = "No active lease found for this property.".localized()
             default:
-                errorMessage = "Error: \(error.localizedDescription)"
+                errorMessage = "Error: \(error.localizedDescription)".localized()
             }
             print("Error sending room report: \(error.localizedDescription)")
         }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomExitEvaluationView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomExitEvaluationView.swift
@@ -21,11 +21,11 @@ struct InventoryRoomExitEvaluationView: View {
     @State private var isReportSent: Bool = false
 
     let stateMapping: [String: String] = [
+        "not_set": "Select room status",
         "broken": "Broken",
         "bad": "Bad",
         "good": "Good",
-        "new": "Good",
-        "medium": "Images"
+        "new": "New"
     ]
 
     var body: some View {

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryStuffView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryStuffView.swift
@@ -32,7 +32,6 @@ struct InventoryStuffView: View {
                 }
                 selectedRoom = inventoryViewModel.localRooms.first { $0.id == roomId }
                 if let room = selectedRoom {
-                    print("OnAppear - Room: \(room.name), checked: \(room.checked), inventory checked: \(room.inventory.allSatisfy { $0.checked })")
                     if room.inventory.isEmpty {
                         await inventoryViewModel.fetchStuff(room)
                     }
@@ -42,7 +41,6 @@ struct InventoryStuffView: View {
         }
         .onChange(of: inventoryViewModel.localRooms) {
             if let updatedRoom = inventoryViewModel.localRooms.first(where: { $0.id == roomId }) {
-                print("OnChange - Updated room: \(updatedRoom.name), checked: \(updatedRoom.checked), inventory checked: \(updatedRoom.inventory.allSatisfy { $0.checked })")
                 selectedRoom = updatedRoom
             }
         }
@@ -140,7 +138,6 @@ struct InventoryStuffView: View {
         Button {
             Task {
                 if let room = selectedRoom {
-                    print("Confirming room: \(room.name)")
                     await inventoryViewModel.markRoomAsChecked(room)
                     dismiss()
                 }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/Managers/InventoryReportManager.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/Managers/InventoryReportManager.swift
@@ -99,7 +99,6 @@ class InventoryReportManager {
 
         viewModel.comment = summarizeResponse.note
         viewModel.selectedStatus = uiStatus
-        print("Report sent successfully: \(summarizeResponse)")
     }
 
     func finalizeInventory() async throws {

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Login/LoginView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Login/LoginView.swift
@@ -11,103 +11,122 @@ struct LoginView: View {
     @StateObject private var viewModel = LoginViewModel()
     @AppStorage("isLoggedIn") var isLoggedIn: Bool = false
     @AppStorage("keepMeSignedIn") var keepMeSignedIn: Bool = false
+    @State private var showError = false
+    @State private var errorMessage: String?
 
     var body: some View {
         NavigationStack {
-            VStack {
-                Spacer()
+            ZStack {
                 VStack {
-                    Text("Welcome back!".localized())
-                        .font(.system(size: 25))
-                        .bold()
-                        .padding(.bottom, 5)
+                    Spacer()
+                    VStack {
+                        Text("Welcome back!".localized())
+                            .font(.system(size: 25))
+                            .bold()
+                            .padding(.bottom, 5)
 
-                    Text("Please enter your details to sign in.".localized())
-                        .font(.system(size: 14))
-                        .padding(.bottom, 50)
+                        Text("Please enter your details to sign in.".localized())
+                            .font(.system(size: 14))
+                            .padding(.bottom, 50)
 
-                    VStack(alignment: .leading, spacing: 15) {
-                        CustomTextInput(title: "Email*", placeholder: "Enter your email", text: $viewModel.model.email, isSecure: false)
-                        CustomTextInput(title: "Password*", placeholder: "Enter your password", text: $viewModel.model.password, isSecure: true)
+                        VStack(alignment: .leading, spacing: 15) {
+                            CustomTextInput(title: "Email*", placeholder: "Enter your email", text: $viewModel.model.email, isSecure: false)
+                            CustomTextInput(title: "Password*", placeholder: "Enter your password", text: $viewModel.model.password, isSecure: true)
 
-                        HStack {
-                            Button(action: {
-                                viewModel.model.keepMeSignedIn.toggle()
-                            }, label: {
-                                HStack {
-                                    Image(systemName: viewModel.model.keepMeSignedIn ? "checkmark.circle.fill" : "circle")
-                                    Text("Keep me signed in".localized())
+                            HStack {
+                                Button(action: {
+                                    viewModel.model.keepMeSignedIn.toggle()
+                                }, label: {
+                                    HStack {
+                                        Image(systemName: viewModel.model.keepMeSignedIn ? "checkmark.circle.fill" : "circle")
+                                        Text("Keep me signed in".localized())
+                                            .font(.system(size: 14))
+                                    }
+                                    .foregroundStyle((Color("btnColor")))
+                                })
+                                Spacer()
+                                Button(action: {}, label: {
+                                    Text("Forgot password?".localized())
                                         .font(.system(size: 14))
+                                })
+                            }
+
+                            Button(action: {
+                                showError = false
+                                errorMessage = nil
+                                Task {
+                                    if let validationError = viewModel.validateFields() {
+                                        errorMessage = validationError
+                                        showError = true
+                                    } else {
+                                        await viewModel.signIn()
+                                    }
                                 }
-                                .foregroundStyle((Color("btnColor")))
+                            }, label: {
+                                Text("Sign In".localized())
+                                    .frame(maxWidth: .infinity)
+                                    .padding()
+                                    .background(Color("btnColor"))
+                                    .foregroundColor(.white)
+                                    .font(.headline)
+                                    .cornerRadius(20)
+                                    .padding(.top, 50)
+                                    .padding(.bottom, 20)
                             })
-                            Spacer()
-                            Button(action: {}, label: {
-                                Text("Forgot password?".localized())
-                                    .font(.system(size: 14))
-                            })
-                        }
 
-                        Button(action: {
-                            Task {
-                                await viewModel.signIn()
-                            }
-                        }, label: {
-                            Text("Sign In".localized())
-                                .frame(maxWidth: .infinity)
-                                .padding()
-                                .background(Color("btnColor"))
-                                .foregroundColor(.white)
-                                .font(.headline)
-                                .cornerRadius(20)
-                                .padding(.top, 50)
-                                .padding(.bottom, 20)
-                        })
-
-                        HStack {
-                            Text("Don't have an account ?".localized())
-                                .font(.subheadline)
-                            NavigationLink(destination: RegisterView()) {
-                                Text("Sign Up".localized())
+                            HStack {
+                                Text("Don't have an account ?".localized())
                                     .font(.subheadline)
-                                    .foregroundColor(.blue)
-                                    .accessibilityIdentifier("signUpLink")
+                                NavigationLink(destination: RegisterView()) {
+                                    Text("Sign Up".localized())
+                                        .font(.subheadline)
+                                        .foregroundColor(.blue)
+                                        .accessibilityIdentifier("signUpLink")
+                                }
                             }
                         }
+                        .padding(.horizontal, 40)
                     }
-                    .padding(.horizontal, 40)
-                }
-                Spacer()
-            }
-            .frame(maxHeight: .infinity)
-            .safeAreaInset(edge: .top) {
-                HStack(spacing: 20) {
-                    Image("KeyzLogo")
-                        .resizable()
-                        .frame(width: 50, height: 50)
-                        .padding(.bottom, 40)
-                    Text("Immotep")
-                        .font(.title)
-                        .bold()
-                        .padding(.bottom, 40)
                     Spacer()
                 }
-                .padding(.leading, 20)
-            }
+                .frame(maxHeight: .infinity)
+                .safeAreaInset(edge: .top) {
+                    HStack(spacing: 20) {
+                        Image("KeyzLogo")
+                            .resizable()
+                            .frame(width: 50, height: 50)
+                            .padding(.bottom, 40)
+                        Text("Immotep")
+                            .font(.title)
+                            .bold()
+                            .padding(.bottom, 40)
+                        Spacer()
+                    }
+                    .padding(.leading, 20)
+                }
 
-            VStack {
-                Spacer()
-                Text(viewModel.loginStatus.localized())
-                .foregroundColor(viewModel.loginStatus == "Login successful!" ? .green : .red)
-                .padding(.top, 10)
-                Spacer()
+                if showError, let message = errorMessage {
+                    ErrorNotificationView(message: message)
+                        .onDisappear {
+                            showError = false
+                            errorMessage = nil
+                        }
+                }
             }
-            .padding()
+            .navigationBarBackButtonHidden(true)
             .navigationDestination(isPresented: $viewModel.isLoggedIn) {
                 OverviewView()
             }
+            .onChange(of: viewModel.loginStatus) {
+                if viewModel.loginStatus.contains("Error") {
+                    errorMessage = viewModel.loginStatus.replacingOccurrences(of: "Error: ", with: "")
+                    showError = true
+                } else if viewModel.loginStatus == "Login successful!" {
+                    showError = false
+                    errorMessage = nil
+                }
+            }
         }
-        .navigationBarBackButtonHidden(true)
     }
 }
 

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Messages/MessagesView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Messages/MessagesView.swift
@@ -11,7 +11,9 @@ struct MessagesView: View {
     var body: some View {
         NavigationStack {
             VStack {
-                TopBar(title: "Messages".localized())
+                TopBar(title: "Keyz".localized())
+                Spacer()
+                Text("Messaging features will be available soon!".localized())
                 Spacer()
             }
             .navigationBarBackButtonHidden(true)

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Overview/OverviewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Overview/OverviewModel.swift
@@ -20,7 +20,7 @@ struct DashboardResponse: Decodable, Equatable {
 }
 
 struct Reminder: Decodable, Identifiable, Equatable {
-    let id: String
+    var id: String
     let priority: String
     let title: String
     let advice: String
@@ -33,7 +33,7 @@ struct PropertyStats: Decodable, Equatable {
     let occupied: Int
     let available: Int
     let pendingInvites: Int
-    let recentlyAdded: [PropertySummary]
+    let recentlyAdded: [PropertySummary]?
 
     enum CodingKeys: String, CodingKey {
         case total = "nbr_total"

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Overview/OverviewViewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Overview/OverviewViewModel.swift
@@ -46,16 +46,14 @@ class OverviewViewModel: ObservableObject {
             let decoder = JSONDecoder()
             let dashboardResponse = try decoder.decode(DashboardResponse.self, from: data)
 
-            var reminderDict: [String: Reminder] = [:]
-            for reminder in dashboardResponse.reminders {
-                if reminderDict[reminder.id] == nil {
-                    reminderDict[reminder.id] = reminder
-                }
+            let remindersWithUniqueIds = dashboardResponse.reminders.enumerated().map { index, reminder in
+                var uniqueReminder = reminder
+                uniqueReminder.id = UUID().uuidString
+                return uniqueReminder
             }
-            let uniqueReminders = reminderDict.values.sorted { $0.id < $1.id }
 
             let uniqueDashboardResponse = DashboardResponse(
-                reminders: Array(uniqueReminders),
+                reminders: remindersWithUniqueIds,
                 properties: dashboardResponse.properties,
                 openDamages: dashboardResponse.openDamages
             )

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/EditPropertyView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/EditPropertyView.swift
@@ -169,9 +169,10 @@ struct EditPropertyView: View {
 
             if let newPhoto = photo, newPhoto != property.photo {
                 do {
-                    let res = try await viewModel.updatePropertyPicture(token: token, propertyPicture: newPhoto, propertyID: propertyId)
+                    let _ = try await viewModel.updatePropertyPicture(token: token, propertyPicture: newPhoto, propertyID: propertyId)
                 } catch {
-                    print("Failed to update property picture: \(error.localizedDescription)")
+                    errorMessage = String(format: NSLocalizedString("Error updating picture: %@", comment: ""), error.localizedDescription)
+                    return
                 }
             }
 

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyView.swift
@@ -12,7 +12,6 @@ struct PropertyView: View {
     @EnvironmentObject var loginViewModel: LoginViewModel
     @State private var tenantProperty: Property?
     @State private var isLoading = false
-    @State private var errorMessage: String?
 
     var body: some View {
         NavigationStack {
@@ -22,14 +21,6 @@ struct PropertyView: View {
                         Spacer()
                         ProgressView()
                             .progressViewStyle(CircularProgressViewStyle())
-                        Spacer()
-                    }
-                } else if let error = errorMessage {
-                    VStack {
-                        Spacer()
-                        Text(error)
-                            .foregroundColor(.red)
-                            .padding()
                         Spacer()
                     }
                 } else if let property = tenantProperty {

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyViewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyViewModel.swift
@@ -87,7 +87,8 @@ class PropertyViewModel: ObservableObject {
             if let leaseId = try await fetchActiveLeaseIdForProperty(propertyId: propertyId, token: try await TokenStorage.getValidAccessToken()) {
                 documents = try await tenantViewModel.fetchTenantPropertyDocuments(leaseId: leaseId, propertyId: propertyId)
             } else {
-                throw NSError(domain: "", code: 404, userInfo: [NSLocalizedDescriptionKey: "No active lease found.".localized()])
+                documents = []
+//                throw NSError(domain: "", code: 404, userInfo: [NSLocalizedDescriptionKey: "No active lease found.".localized()])
             }
         } else {
             documents = try await ownerViewModel.fetchPropertyDocuments(propertyId: propertyId)

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/ViewModels/OwnerPropertyViewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/ViewModels/OwnerPropertyViewModel.swift
@@ -381,6 +381,9 @@ class OwnerPropertyViewModel: ObservableObject {
         let responseBody = String(data: data, encoding: .utf8) ?? "Unable to decode response"
         
         guard (200...299).contains(httpResponse.statusCode) else {
+            if (httpResponse.statusCode == 404) {
+                return []
+            }
             throw NSError(domain: "", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: "Failed with status code: \(httpResponse.statusCode) - \(responseBody)".localized()])
         }
         


### PR DESCRIPTION
Context:
When connecting to the app without selecting the 'keep connected' button, all user data are erased when the app is closed. In these datas, is the 'IsLoggedIn' state that is used to know if the user should bypass the login view when launching the app or not.

Issue:
IsLoggedIn state wasn't properly erased when leaving the app, causing the user to bypass the 'LoginView' (and be directly IN the app), but the user was then not defined (all his datas being erased), forcing him to disconnect and reconnect manually to his account.

Fix: 
Modified the data erasure logic in AppDelegate to ensure the isLoggedIn state is correctly cleared when the app is closed, aligning it with the erasure of other user data when the 'keep connected' option is not selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an error notification banner for displaying error messages across various views.
  - Added user-facing error messages and feedback in property creation, editing, login, and overview screens.
  - Enhanced localization support for inventory and added new French translations.

- **Improvements**
  - Centralized and improved error handling in multiple views, providing clearer feedback to users.
  - Updated color theming for a more consistent and accessible interface.
  - Improved handling of document fetching to avoid unnecessary errors when no documents are found.

- **Bug Fixes**
  - Corrected status mappings and removed incorrect options in inventory evaluation views.
  - Fixed logic to ensure reminders have unique IDs.

- **Refactor**
  - Simplified and cleaned up code by removing debug print statements and unused error handling blocks.

- **Chores**
  - Updated localization files with new and removed translation keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->