### PR TITLE
Fix AI error handling

### DIFF
--- a/Code/Server/controllers/ai.go
+++ b/Code/Server/controllers/ai.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"encoding/base64"
+	"errors"
 	"log"
 	"net/http"
 	"strings"
@@ -13,6 +14,8 @@ import (
 	"keyz/backend/services/database"
 	"keyz/backend/utils"
 )
+
+const chatGPTerror = "error"
 
 func imagesToBase64Strings(images []db.ImageModel) []string {
 	res := make([]string, len(images))
@@ -45,35 +48,60 @@ func GenerateSummary(c *gin.Context) {
 		return
 	}
 
-	if req.Type == "room" {
-		room := database.GetRoomByID(req.Id)
-		chatGPTres, err := chatgpt.SummarizeRoom(room.Name, req.Pictures)
-		if err != nil {
-			utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, err)
-			return
-		}
-		splitted := strings.Split(chatGPTres, "|")
-		resp := models.SummarizeResponse{
-			State:       splitted[0],
-			Cleanliness: splitted[1],
-			Note:        splitted[2],
-		}
-		c.JSON(http.StatusOK, resp)
-	} else {
-		furniture := database.GetFurnitureByID(req.Id)
-		chatGPTres, err := chatgpt.SummarizeFurniture(furniture.Name, req.Pictures)
-		if err != nil {
-			utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, err)
-			return
-		}
-		splitted := strings.Split(chatGPTres, "|")
-		resp := models.SummarizeResponse{
-			State:       splitted[0],
-			Cleanliness: splitted[1],
-			Note:        splitted[2],
-		}
-		c.JSON(http.StatusOK, resp)
+	switch req.Type {
+	case "room":
+		handleRoomSummary(c, req)
+	case "furniture":
+		handleFurnitureSummary(c, req)
 	}
+}
+
+func handleRoomSummary(c *gin.Context, req models.SummarizeRequest) {
+	room := database.GetRoomByID(req.Id)
+	chatGPTres, err := chatgpt.SummarizeRoom(room.Name, req.Pictures)
+	if err != nil {
+		utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, err)
+		return
+	}
+	splitted := strings.Split(chatGPTres, "|")
+	if len(splitted) == 2 && splitted[0] == chatGPTerror {
+		utils.SendError(c, http.StatusBadRequest, utils.ErrorRequestChatGPTAPI, errors.New(splitted[1]))
+		return
+	} else if len(splitted) != 3 {
+		log.Println(chatGPTres)
+		utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, errors.New("unexpected response format from ChatGPT"))
+		return
+	}
+	resp := models.SummarizeResponse{
+		State:       splitted[0],
+		Cleanliness: splitted[1],
+		Note:        splitted[2],
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func handleFurnitureSummary(c *gin.Context, req models.SummarizeRequest) {
+	furniture := database.GetFurnitureByID(req.Id)
+	chatGPTres, err := chatgpt.SummarizeFurniture(furniture.Name, req.Pictures)
+	if err != nil {
+		utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, err)
+		return
+	}
+	splitted := strings.Split(chatGPTres, "|")
+	if len(splitted) == 2 && splitted[0] == chatGPTerror {
+		utils.SendError(c, http.StatusBadRequest, utils.ErrorRequestChatGPTAPI, errors.New(splitted[1]))
+		return
+	} else if len(splitted) != 3 {
+		log.Println(chatGPTres)
+		utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, errors.New("unexpected response format from ChatGPT"))
+		return
+	}
+	resp := models.SummarizeResponse{
+		State:       splitted[0],
+		Cleanliness: splitted[1],
+		Note:        splitted[2],
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 // GenerateComparison godoc
@@ -117,45 +145,67 @@ func GenerateComparison(c *gin.Context) {
 func handleRoomComparison(c *gin.Context, req models.CompareRequest, oldReport *db.InventoryReportModel) {
 	for _, rs := range oldReport.RoomStates() {
 		if rs.RoomID == req.Id {
-			room := database.GetRoomByID(req.Id)
-			chatGPTres, err := chatgpt.CompareRoom(room.Name, rs, imagesToBase64Strings(rs.Pictures()), req.Pictures)
-			if err != nil {
-				utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, err)
-				return
-			}
-			log.Println(chatGPTres)
-			splitted := strings.Split(chatGPTres, "|")
-			resp := models.SummarizeResponse{
-				State:       splitted[0],
-				Cleanliness: splitted[1],
-				Note:        splitted[2],
-			}
-			c.JSON(http.StatusOK, resp)
+			handleRoomComparison2(c, req, rs)
 			return
 		}
 	}
 	utils.SendError(c, http.StatusNotFound, utils.RoomNotFound, nil)
 }
 
+func handleRoomComparison2(c *gin.Context, req models.CompareRequest, rs db.RoomStateModel) {
+	room := database.GetRoomByID(req.Id)
+	chatGPTres, err := chatgpt.CompareRoom(room.Name, rs, imagesToBase64Strings(rs.Pictures()), req.Pictures)
+	if err != nil {
+		utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, err)
+		return
+	}
+	splitted := strings.Split(chatGPTres, "|")
+	if len(splitted) == 2 && splitted[0] == chatGPTerror {
+		utils.SendError(c, http.StatusBadRequest, utils.ErrorRequestChatGPTAPI, errors.New(splitted[1]))
+		return
+	} else if len(splitted) != 3 {
+		log.Println(chatGPTres)
+		utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, errors.New("unexpected response format from ChatGPT"))
+		return
+	}
+	resp := models.SummarizeResponse{
+		State:       splitted[0],
+		Cleanliness: splitted[1],
+		Note:        splitted[2],
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
 func handleFurnitureComparison(c *gin.Context, req models.CompareRequest, oldReport *db.InventoryReportModel) {
 	for _, fs := range oldReport.FurnitureStates() {
 		if fs.FurnitureID == req.Id {
-			furniture := database.GetFurnitureByID(req.Id)
-			chatGPTres, err := chatgpt.CompareFurniture(furniture.Name, fs, imagesToBase64Strings(fs.Pictures()), req.Pictures)
-			if err != nil {
-				utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, err)
-				return
-			}
-			log.Println(chatGPTres)
-			splitted := strings.Split(chatGPTres, "|")
-			resp := models.SummarizeResponse{
-				State:       splitted[0],
-				Cleanliness: splitted[1],
-				Note:        splitted[2],
-			}
-			c.JSON(http.StatusOK, resp)
+			handleFurnitureComparison2(c, req, fs)
 			return
 		}
 	}
 	utils.SendError(c, http.StatusNotFound, utils.FurnitureNotFound, nil)
+}
+
+func handleFurnitureComparison2(c *gin.Context, req models.CompareRequest, fs db.FurnitureStateModel) {
+	furniture := database.GetFurnitureByID(req.Id)
+	chatGPTres, err := chatgpt.CompareFurniture(furniture.Name, fs, imagesToBase64Strings(fs.Pictures()), req.Pictures)
+	if err != nil {
+		utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, err)
+		return
+	}
+	splitted := strings.Split(chatGPTres, "|")
+	if len(splitted) == 2 && splitted[0] == chatGPTerror {
+		utils.SendError(c, http.StatusBadRequest, utils.ErrorRequestChatGPTAPI, errors.New(splitted[1]))
+		return
+	} else if len(splitted) != 3 {
+		log.Println(chatGPTres)
+		utils.SendError(c, http.StatusInternalServerError, utils.ErrorRequestChatGPTAPI, errors.New("unexpected response format from ChatGPT"))
+		return
+	}
+	resp := models.SummarizeResponse{
+		State:       splitted[0],
+		Cleanliness: splitted[1],
+		Note:        splitted[2],
+	}
+	c.JSON(http.StatusOK, resp)
 }

--- a/Code/Server/controllers/ai.go
+++ b/Code/Server/controllers/ai.go
@@ -53,6 +53,9 @@ func GenerateSummary(c *gin.Context) {
 		handleRoomSummary(c, req)
 	case "furniture":
 		handleFurnitureSummary(c, req)
+	default:
+		utils.SendError(c, http.StatusBadRequest, utils.MissingFields, errors.New("invalid type: must be 'room' or 'furniture'"))
+		return
 	}
 }
 
@@ -139,6 +142,9 @@ func GenerateComparison(c *gin.Context) {
 		handleRoomComparison(c, req, oldReport)
 	case "furniture":
 		handleFurnitureComparison(c, req, oldReport)
+	default:
+		utils.SendError(c, http.StatusBadRequest, utils.MissingFields, errors.New("invalid type: must be 'room' or 'furniture'"))
+		return
 	}
 }
 

--- a/Code/Server/services/chatgpt/chatgpt.go
+++ b/Code/Server/services/chatgpt/chatgpt.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"log"
 	"net/http"
 	"os"
 
@@ -47,6 +46,7 @@ DON'T SEND ANYTHING ELSE IN THE RESPONSE.
 In case of error, your response must strictly follow this format:
 error|<error_message>
 Ex: "error|The image does not correspond to the name provided."
+DON'T SEND ANYTHING ELSE IN THE ERROR RESPONSE.
 
 Where:
 - **State** represents the overall condition of the room and must be one of the following: broken, needsRepair, bad, medium, good, new.
@@ -68,6 +68,7 @@ DON'T SEND ANYTHING ELSE IN THE RESPONSE.
 In case of error, your response must strictly follow this format:
 error|<error_message>
 Ex: "error|The image does not correspond to the name provided."
+DON'T SEND ANYTHING ELSE IN THE ERROR RESPONSE.
 
 Where:
 - **State** represents the overall condition of the furniture and must be one of the following: broken, needsRepair, bad, medium, good, new.
@@ -201,7 +202,6 @@ func summarize(stuffType string, name string, picturesUri []string) (string, err
 	if err != nil {
 		return "", err
 	}
-	log.Println(resp)
 
 	var result Response
 	if err := json.Unmarshal([]byte(resp), &result); err != nil {
@@ -267,7 +267,6 @@ func compare(stuffType string, initialState string, initialCleanliness string, i
 	if err != nil {
 		return "", err
 	}
-	log.Println(resp)
 
 	var result Response
 	if err := json.Unmarshal([]byte(resp), &result); err != nil {


### PR DESCRIPTION
fix chatGPT error handling when providing the same image twice in comparison
was not handling the error pattern in the response, so it crashed and sent a HTTP 500 code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced error handling and response validation for summary and comparison features, providing clearer and more consistent error messages.
  - Improved internal logic for generating summaries and comparisons, increasing reliability and maintainability.

- **Style**
  - Removed debug logging for a cleaner user experience.

- **Documentation**
  - Clarified prompt instructions to ensure proper error response formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->