### PR TITLE
fix(widgets): size and content updated

### DIFF
--- a/Code/Web/src/components/features/Overview/Widgets/OpenDamages/OpenDamages.tsx
+++ b/Code/Web/src/components/features/Overview/Widgets/OpenDamages/OpenDamages.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
-import { Tooltip } from 'antd'
 import { LoadingOutlined } from '@ant-design/icons'
 
 import { StatusTag, Empty, Badge } from '@/components/common'
@@ -90,15 +89,9 @@ const OpenDamages: React.FC<OpenDamagesProps> = ({
               aria-label={`${damage.created_at}: ${damage.comment}`}
             >
               <div className={style.damageInformationsContainer}>
-                <Tooltip
-                  title={`${damage.property_name || '-'} > ${damage.room_name || '-'}`}
-                  placement="topLeft"
-                >
-                  <span className={style.damageInfosContainer}>
-                    {damage.property_name || '-'} {'>'}{' '}
-                    {damage.room_name || '-'}
-                  </span>
-                </Tooltip>
+                <span className={style.damageInfosContainer}>
+                  {damage.property_name || '-'} {'>'} {damage.room_name || '-'}
+                </span>
                 <span className={style.dateText}>
                   {toLocaleDate(damage.created_at, 'short')}
                 </span>
@@ -108,18 +101,14 @@ const OpenDamages: React.FC<OpenDamagesProps> = ({
                   className={style.damageComment}
                   color="blue"
                   text={
-                    <Tooltip title={damage.comment} placement="topLeft">
-                      <span style={{ fontWeight: 700 }}>{damage.comment}</span>
-                    </Tooltip>
+                    <span style={{ fontWeight: 700 }}>{damage.comment}</span>
                   }
                 />
               ) : (
                 <div className={style.damageCommentContainer}>
-                  <Tooltip title={damage.comment} placement="topLeft">
-                    <span className={style.damageCommentWithoutBadge}>
-                      {damage.comment}
-                    </span>
-                  </Tooltip>
+                  <span className={style.damageCommentWithoutBadge}>
+                    {damage.comment}
+                  </span>
                   <StatusTag
                     value={damage.priority}
                     colorMap={{

--- a/Code/Web/src/components/features/Overview/Widgets/Reminders/Reminders.tsx
+++ b/Code/Web/src/components/features/Overview/Widgets/Reminders/Reminders.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
-import { Tooltip } from 'antd'
 import { LoadingOutlined } from '@ant-design/icons'
 
 import { StatusTag, Empty } from '@/components/common'
@@ -70,9 +69,7 @@ const Reminders: React.FC<RemindersProps> = ({
               aria-label={`${reminder.title}: ${reminder.advice}`}
             >
               <div className={style.reminderTexts}>
-                <Tooltip title={reminder.title} placement="topLeft">
-                  <span className={style.titleText}>{reminder.title}</span>
-                </Tooltip>
+                <span className={style.titleText}>{reminder.title}</span>
                 <div className={style.reminderheader}>
                   <StatusTag
                     value={reminder.priority}
@@ -85,11 +82,9 @@ const Reminders: React.FC<RemindersProps> = ({
                     i18nPrefix="pages.real_property_details.tabs.damage.priority"
                     defaultColor="gray"
                   />
-                  <Tooltip title={reminder.advice} placement="topLeft">
-                    <span className={style.descriptionText}>
-                      {reminder.advice}
-                    </span>
-                  </Tooltip>
+                  <span className={style.descriptionText}>
+                    {reminder.advice}
+                  </span>
                 </div>
               </div>
             </div>

--- a/Code/Web/src/components/features/Overview/Widgets/Reminders/Reminders.tsx
+++ b/Code/Web/src/components/features/Overview/Widgets/Reminders/Reminders.tsx
@@ -69,7 +69,9 @@ const Reminders: React.FC<RemindersProps> = ({
               aria-label={`${reminder.title}: ${reminder.advice}`}
             >
               <div className={style.reminderTexts}>
-                <span className={style.titleText}>{reminder.title}</span>
+                <span className={style.titleText} title={reminder.title}>
+                  {reminder.title}
+                </span>
                 <div className={style.reminderheader}>
                   <StatusTag
                     value={reminder.priority}

--- a/Code/Web/src/views/Overview/Overview.tsx
+++ b/Code/Web/src/views/Overview/Overview.tsx
@@ -88,13 +88,13 @@ const Overview: React.FC = () => {
         x: 7,
         y: 0,
         w: 3,
-        h: 2,
+        h: 3,
         children: (
           <Reminders
             reminders={reminders}
             loading={loading}
             error={error}
-            height={2}
+            height={3}
           />
         )
       },
@@ -104,13 +104,13 @@ const Overview: React.FC = () => {
         x: 0,
         y: 0,
         w: 3,
-        h: 2,
+        h: 3,
         children: (
           <OpenDamages
             openDamages={openDamages}
             loading={loading}
             error={error}
-            height={2}
+            height={3}
           />
         )
       },
@@ -126,7 +126,7 @@ const Overview: React.FC = () => {
             openDamages={openDamages}
             loading={loading}
             error={error}
-            height={2}
+            height={1}
           />
         )
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed tooltip functionality from the Open Damages and Reminders widgets; text is now displayed without tooltips.

- **Style**
  - Adjusted the initial layout heights of the Reminders, Open Damages, and Damages Repartition widgets for improved display and sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->