### PR TITLE
Global iOS app bugfixes

### DIFF
--- a/Code/Mobile_iOS/Keyz/Sources/Components/CustomAlert.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Components/CustomAlert.swift
@@ -6,10 +6,13 @@
 //
 
 import SwiftUI
+import Combine
 
 struct CustomAlert: View {
     @Binding var isActive: Bool
     @Binding var textFieldInput: String
+    @State private var isClosing: Bool = false
+    @State private var keyboardHeight: CGFloat = 0
 
     let title: String
     let message: String
@@ -30,9 +33,9 @@ struct CustomAlert: View {
 
             VStack {
                 Text(title)
-                    .font(.title2)
+                    .font(.title3)
                     .bold()
-                    .padding()
+                    .padding(.bottom, 10)
                     .foregroundStyle(Color("textColor"))
 
                 Text(message)
@@ -45,8 +48,6 @@ struct CustomAlert: View {
                     .frame(height: 35)
                     .background(RoundedRectangle(cornerRadius: 8).fill(Color("textfieldBackground")))
                     .padding(.horizontal)
-
-
 
                 HStack {
                     if let secondaryButtonTitle = secondaryButtonTitle {
@@ -61,7 +62,6 @@ struct CustomAlert: View {
                                 Text(secondaryButtonTitle)
                                     .font(.system(size: 16, weight: .bold))
                                     .foregroundColor(.white)
-                                    .padding()
                             }
                             .frame(height: 50)
                         }
@@ -73,12 +73,11 @@ struct CustomAlert: View {
                     } label: {
                         ZStack {
                             RoundedRectangle(cornerRadius: 20)
-                                .foregroundColor(.red)
+                                .foregroundColor(Color("LightBlue"))
 
                             Text(buttonTitle)
                                 .font(.system(size: 16, weight: .bold))
                                 .foregroundColor(.white)
-                                .padding()
                         }
                         .frame(height: 50)
                     }
@@ -89,23 +88,20 @@ struct CustomAlert: View {
             .padding()
             .background(Color("basicWhiteBlack"))
             .clipShape(RoundedRectangle(cornerRadius: 20))
-            .overlay(alignment: .topTrailing) {
-                Button {
-                    close()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.title2)
-                        .fontWeight(.medium)
-                }
-                .tint(Color("textColor"))
-                .padding()
-            }
             .shadow(radius: 20)
-            .padding(30)
+            .padding(.horizontal, 30)
+            .padding(.bottom, keyboardHeight)
             .offset(x: 0, y: offset)
             .onAppear {
-                withAnimation(.spring()) {
-                    offset = 0
+                if !isClosing {
+                    withAnimation(.spring) {
+                        offset = 0
+                    }
+                }
+            }
+            .onReceive(keyboardPublisher) { height in
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    keyboardHeight = height / 2
                 }
             }
         }
@@ -113,10 +109,30 @@ struct CustomAlert: View {
     }
 
     func close() {
-        withAnimation(.spring()) {
+        if isClosing { return }
+        isClosing = true
+        withAnimation(.easeInOut(duration: 0.2)) {
             offset = 1000
-            isActive = false
         }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            isActive = false
+            isClosing = false
+            offset = 1000
+        }
+    }
+
+    private var keyboardPublisher: AnyPublisher<CGFloat, Never> {
+        Publishers.Merge(
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillShowNotification)
+                .map { notification in
+                    (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect)?.height ?? 0
+                },
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillHideNotification)
+                .map { _ in 0 }
+        )
+        .eraseToAnyPublisher()
     }
 }
 
@@ -131,6 +147,8 @@ struct CustomAlertTwoButtons: View {
     let secondaryAction: (() -> Void)?
 
     @State private var offset: CGFloat = 1000
+    @State private var isClosing: Bool = false
+    @State private var keyboardHeight: CGFloat = 0
 
     var body: some View {
         ZStack {
@@ -142,9 +160,9 @@ struct CustomAlertTwoButtons: View {
 
             VStack {
                 Text(title)
-                    .font(.title2)
+                    .font(.title3)
                     .bold()
-                    .padding()
+                    .padding(.bottom, 10)
                     .foregroundStyle(Color("textColor"))
 
                 Text(message)
@@ -166,7 +184,6 @@ struct CustomAlertTwoButtons: View {
                                 Text(secondaryButtonTitle)
                                     .font(.system(size: 16, weight: .bold))
                                     .foregroundColor(.white)
-                                    .padding()
                             }
                             .frame(height: 50)
                         }
@@ -178,12 +195,11 @@ struct CustomAlertTwoButtons: View {
                     } label: {
                         ZStack {
                             RoundedRectangle(cornerRadius: 20)
-                                .foregroundColor(.red)
+                                .foregroundColor(Color("LightBlue"))
 
                             Text(buttonTitle)
                                 .font(.system(size: 16, weight: .bold))
                                 .foregroundColor(.white)
-                                .padding()
                         }
                         .frame(height: 50)
                     }
@@ -194,23 +210,20 @@ struct CustomAlertTwoButtons: View {
             .padding()
             .background(Color("basicWhiteBlack"))
             .clipShape(RoundedRectangle(cornerRadius: 20))
-            .overlay(alignment: .topTrailing) {
-                Button {
-                    close()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.title2)
-                        .fontWeight(.medium)
-                }
-                .tint(Color("textColor"))
-                .padding()
-            }
             .shadow(radius: 20)
-            .padding(30)
+            .padding(.horizontal, 30)
+            .padding(.bottom, keyboardHeight)
             .offset(x: 0, y: offset)
             .onAppear {
-                withAnimation(.spring()) {
-                    offset = 0
+                if !isClosing {
+                    withAnimation(.spring) {
+                        offset = 0
+                    }
+                }
+            }
+            .onReceive(keyboardPublisher) { height in
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    keyboardHeight = height / 2
                 }
             }
         }
@@ -218,10 +231,30 @@ struct CustomAlertTwoButtons: View {
     }
 
     func close() {
-        withAnimation(.spring()) {
+        if isClosing { return }
+        isClosing = true
+        withAnimation(.easeInOut(duration: 0.2)) {
             offset = 1000
-            isActive = false
         }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            isActive = false
+            isClosing = false
+            offset = 1000
+        }
+    }
+
+    private var keyboardPublisher: AnyPublisher<CGFloat, Never> {
+        Publishers.Merge(
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillShowNotification)
+                .map { notification in
+                    (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect)?.height ?? 0
+                },
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillHideNotification)
+                .map { _ in 0 }
+        )
+        .eraseToAnyPublisher()
     }
 }
 
@@ -238,6 +271,8 @@ struct CustomAlertWithTwoTextFields: View {
     @State private var offset: CGFloat = 1000
     @State private var textFieldInputString: String = ""
     @State private var textFieldInputInt: String = ""
+    @State private var isClosing: Bool = false
+    @State private var keyboardHeight: CGFloat = 0
 
     var body: some View {
         ZStack {
@@ -249,9 +284,9 @@ struct CustomAlertWithTwoTextFields: View {
 
             VStack {
                 Text(title)
-                    .font(.title2)
+                    .font(.title3)
                     .bold()
-                    .padding()
+                    .padding(.bottom, 10)
                     .foregroundStyle(Color("textColor"))
 
                 Text(message)
@@ -260,12 +295,16 @@ struct CustomAlertWithTwoTextFields: View {
                     .padding(.bottom, 20)
                     .foregroundStyle(Color("textColor"))
 
-                TextField("Enter a new furniture name", text: $textFieldInputString)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                TextField("Enter a new furniture name".localized(), text: $textFieldInputString)
+                    .frame(height: 35)
+                    .padding(.leading, 10)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Color("textfieldBackground")))
                     .padding(.horizontal)
 
-                TextField("Enter the furniture quantity", text: $textFieldInputInt)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                TextField("Enter the furniture quantity".localized(), text: $textFieldInputInt)
+                    .frame(height: 35)
+                    .padding(.leading, 10)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Color("textfieldBackground")))
                     .padding(.horizontal)
                     .keyboardType(.numberPad)
                     .onChange(of: textFieldInputInt) {
@@ -288,7 +327,6 @@ struct CustomAlertWithTwoTextFields: View {
                                 Text(secondaryButtonTitle)
                                     .font(.system(size: 16, weight: .bold))
                                     .foregroundColor(.white)
-                                    .padding()
                             }
                             .frame(height: 50)
                         }
@@ -301,12 +339,11 @@ struct CustomAlertWithTwoTextFields: View {
                     } label: {
                         ZStack {
                             RoundedRectangle(cornerRadius: 20)
-                                .foregroundColor(.red)
+                                .foregroundColor(Color("LightBlue"))
 
                             Text(buttonTitle)
                                 .font(.system(size: 16, weight: .bold))
                                 .foregroundColor(.white)
-                                .padding()
                         }
                         .frame(height: 50)
                     }
@@ -316,35 +353,53 @@ struct CustomAlertWithTwoTextFields: View {
             }
             .fixedSize(horizontal: false, vertical: true)
             .padding()
-            .background(Color("primaryBackgroundColor"))
+            .background(Color("basicWhiteBlack"))
             .clipShape(RoundedRectangle(cornerRadius: 20))
-            .overlay(alignment: .topTrailing) {
-                Button {
-                    close()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.title2)
-                        .fontWeight(.medium)
-                }
-                .tint(Color("textColor"))
-                .padding()
-            }
             .shadow(radius: 20)
-            .padding(30)
+            .padding(.horizontal, 30)
+            .padding(.bottom, keyboardHeight)
             .offset(x: 0, y: offset)
             .onAppear {
-                withAnimation(.spring()) {
-                    offset = 0
+                if !isClosing {
+                    withAnimation(.spring) {
+                        offset = 0
+                    }
+                }
+            }
+            .onReceive(keyboardPublisher) { height in
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    keyboardHeight = height / 2
                 }
             }
         }
         .ignoresSafeArea()
     }
+
     func close() {
-        withAnimation(.spring()) {
+        if isClosing { return }
+        isClosing = true
+        withAnimation(.easeInOut(duration: 0.2)) {
             offset = 1000
-            isActive = false
         }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            isActive = false
+            isClosing = false
+            offset = 1000
+        }
+    }
+
+    private var keyboardPublisher: AnyPublisher<CGFloat, Never> {
+        Publishers.Merge(
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillShowNotification)
+                .map { notification in
+                    (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect)?.height ?? 0
+                },
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillHideNotification)
+                .map { _ in 0 }
+        )
+        .eraseToAnyPublisher()
     }
 }
 
@@ -352,6 +407,8 @@ struct CustomAlertWithTextAndDropdown: View {
     @Binding var isActive: Bool
     @Binding var textFieldInput: String
     @State private var selectedRoomType: String
+    @State private var isClosing: Bool = false
+    @State private var keyboardHeight: CGFloat = 0
 
     private let roomTypeMapping: [(apiValue: String, displayName: String)] = [
         ("dressing", "dressing".localized()),
@@ -412,9 +469,9 @@ struct CustomAlertWithTextAndDropdown: View {
 
             VStack {
                 Text(title)
-                    .font(.title2)
+                    .font(.title3)
                     .bold()
-                    .padding()
+                    .padding(.bottom, 10)
                     .foregroundStyle(Color("textColor"))
 
                 Text(message)
@@ -429,7 +486,7 @@ struct CustomAlertWithTextAndDropdown: View {
                     .background(RoundedRectangle(cornerRadius: 8).fill(Color("textfieldBackground")))
                     .padding(.horizontal)
 
-                Picker("Room Type", selection: $selectedRoomType) {
+                Picker("Room Type".localized(), selection: $selectedRoomType) {
                     ForEach(roomTypeMapping, id: \.apiValue) { mapping in
                         Text(mapping.displayName.capitalized)
                             .tag(mapping.apiValue)
@@ -456,7 +513,6 @@ struct CustomAlertWithTextAndDropdown: View {
                                 Text(secondaryButtonTitle)
                                     .font(.system(size: 16, weight: .bold))
                                     .foregroundColor(.white)
-                                    .padding()
                             }
                             .frame(height: 50)
                         }
@@ -468,12 +524,11 @@ struct CustomAlertWithTextAndDropdown: View {
                     } label: {
                         ZStack {
                             RoundedRectangle(cornerRadius: 20)
-                                .foregroundColor(.red)
+                                .foregroundColor(Color("LightBlue"))
 
                             Text(buttonTitle)
                                 .font(.system(size: 16, weight: .bold))
                                 .foregroundColor(.white)
-                                .padding()
                         }
                         .frame(height: 50)
                     }
@@ -485,23 +540,20 @@ struct CustomAlertWithTextAndDropdown: View {
             .padding()
             .background(Color("basicWhiteBlack"))
             .clipShape(RoundedRectangle(cornerRadius: 20))
-            .overlay(alignment: .topTrailing) {
-                Button {
-                    close()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.title2)
-                        .fontWeight(.medium)
-                }
-                .tint(Color("textColor"))
-                .padding()
-            }
             .shadow(radius: 20)
-            .padding(30)
+            .padding(.horizontal, 30)
+            .padding(.bottom, keyboardHeight)
             .offset(x: 0, y: offset)
             .onAppear {
-                withAnimation(.spring()) {
-                    offset = 0
+                if !isClosing {
+                    withAnimation(.spring) {
+                        offset = 0
+                    }
+                }
+            }
+            .onReceive(keyboardPublisher) { height in
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    keyboardHeight = height / 2
                 }
             }
         }
@@ -509,10 +561,30 @@ struct CustomAlertWithTextAndDropdown: View {
     }
 
     func close() {
-        withAnimation(.spring()) {
+        if isClosing { return }
+        isClosing = true
+        withAnimation(.easeInOut(duration: 0.2)) {
             offset = 1000
-            isActive = false
         }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            isActive = false
+            isClosing = false
+            offset = 1000
+        }
+    }
+
+    private var keyboardPublisher: AnyPublisher<CGFloat, Never> {
+        Publishers.Merge(
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillShowNotification)
+                .map { notification in
+                    (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect)?.height ?? 0
+                },
+            NotificationCenter.default
+                .publisher(for: UIResponder.keyboardWillHideNotification)
+                .map { _ in 0 }
+        )
+        .eraseToAnyPublisher()
     }
 }
 
@@ -522,10 +594,10 @@ struct CustomAlert_Previews: PreviewProvider {
             CustomAlert(
                 isActive: .constant(true),
                 textFieldInput: .constant(""),
-                title: "Alerte avec Saisie",
-                message: "Veuillez entrer quelque chose :",
-                buttonTitle: "Valider",
-                secondaryButtonTitle: "Annuler",
+                title: "Alerte avec Saisie".localized(),
+                message: "Veuillez entrer quelque chose :".localized(),
+                buttonTitle: "Valider".localized(),
+                secondaryButtonTitle: "Annuler".localized(),
                 action: {
                     print("Validation action")
                 },
@@ -536,12 +608,26 @@ struct CustomAlert_Previews: PreviewProvider {
 
             CustomAlertTwoButtons(
                 isActive: .constant(true),
-                title: "Alerte Double",
-                message: "Ceci est une alerte avec deux boutons.",
-                buttonTitle: "Confirmer",
-                secondaryButtonTitle: "Annuler",
+                title: "Alerte Double".localized(),
+                message: "Ceci est une alerte avec deux boutons.".localized(),
+                buttonTitle: "Confirmer".localized(),
+                secondaryButtonTitle: "Annuler".localized(),
                 action: {
                     print("Confirmation action")
+                },
+                secondaryAction: {
+                    print("Annulation action")
+                }
+            )
+
+            CustomAlertWithTwoTextFields(
+                isActive: .constant(true),
+                title: "Alerte avec Deux Champs".localized(),
+                message: "Entrez un nom et une quantité :".localized(),
+                buttonTitle: "Ajouter".localized(),
+                secondaryButtonTitle: "Annuler".localized(),
+                action: { name, quantity in
+                    print("Nom: \(name), Quantité: \(quantity)")
                 },
                 secondaryAction: {
                     print("Annulation action")
@@ -551,10 +637,10 @@ struct CustomAlert_Previews: PreviewProvider {
             CustomAlertWithTextAndDropdown(
                 isActive: .constant(true),
                 textFieldInput: .constant(""),
-                title: "Alerte avec Texte et Dropdown",
-                message: "Entrez un nom et sélectionnez un type :",
-                buttonTitle: "Ajouter",
-                secondaryButtonTitle: "Annuler",
+                title: "Alerte avec Texte et Dropdown".localized(),
+                message: "Entrez un nom et sélectionnez un type :".localized(),
+                buttonTitle: "Ajouter".localized(),
+                secondaryButtonTitle: "Annuler".localized(),
                 action: { name, type in
                     print("Nom: \(name), Type: \(type)")
                 },
@@ -565,4 +651,3 @@ struct CustomAlert_Previews: PreviewProvider {
         }
     }
 }
-

--- a/Code/Mobile_iOS/Keyz/Sources/Components/DebugAPIRequest.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Components/DebugAPIRequest.swift
@@ -1,0 +1,55 @@
+//
+//  DebugAPIRequest.swift
+//  Keyz
+//
+//  Created by Liebenguth Alessio on 20/06/2025.
+//
+
+import Foundation
+
+func debugPrintAPIRequest(_ request: URLRequest) {
+    print("===== Debug API Request =====")
+    print("URL: \(request.url?.absoluteString ?? "No URL")")
+    print("HTTP Method: \(request.httpMethod ?? "No Method")")
+    print("Headers:")
+    if let headers = request.allHTTPHeaderFields, !headers.isEmpty {
+        for (key, value) in headers {
+            print("  \(key): \(value)")
+        }
+    } else {
+        print("  No headers")
+    }
+    print("Body:")
+    if let body = request.httpBody, let bodyString = String(data: body, encoding: .utf8) {
+        do {
+            let jsonObject = try JSONSerialization.jsonObject(with: body, options: [])
+            let prettyData = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
+            if let prettyString = String(data: prettyData, encoding: .utf8) {
+                print(prettyString)
+            } else {
+                print(bodyString)
+            }
+        } catch {
+            print(bodyString)
+        }
+    } else {
+        print("  No body")
+    }
+    print("============================")
+}
+
+func debugPrintAPIResponse(_ data: Data?, response: URLResponse?, error: Error?) {
+    print("===== Debug API Response =====")
+    if let httpResponse = response as? HTTPURLResponse {
+        print("Status Code: \(httpResponse.statusCode)")
+    }
+    if let data = data, let responseString = String(data: data, encoding: .utf8) {
+        print("Response Body: \(responseString)")
+    } else {
+        print("No response body")
+    }
+    if let error = error {
+        print("Error: \(error.localizedDescription)")
+    }
+    print("================ =============")
+}

--- a/Code/Mobile_iOS/Keyz/Sources/Components/TopBar.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Components/TopBar.swift
@@ -17,7 +17,7 @@ struct TopBar: View {
                     .frame(width: 50, height: 50)
 
                 Text(title)
-                    .font(.title)
+                    .font(.title2)
                     .bold()
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Code/Mobile_iOS/Keyz/Sources/Resources/en.lproj/Localizable.strings
+++ b/Code/Mobile_iOS/Keyz/Sources/Resources/en.lproj/Localizable.strings
@@ -170,3 +170,31 @@
 "High_damage" = "High";
 "Medium_damage" = "Medium";
 "Low_damage" = "Low";
+
+"Room Type" = "Room Type";
+"Inventory Report" = "Inventory Report";
+"Image(s)" = "Image(s)";
+"Property or old report not found. Please check the property details." = "Property or old report not found. Please check the property details.";
+"No previous inventory report found for comparison." = "No previous inventory report found for comparison.";
+
+"Room Analysis" = "Room Analysis";
+"Select room status" = "Select room status";
+"Send Room Report" = "Send Room Report";
+"Broken" = "Broken";
+"Bad" = "Bad";
+"Good" = "Good";
+"New" = "New";
+
+"Choose a name and type for your new room:" = "Choose a name and type for your new room:";
+"Are you sure you want to delete the room %@" = "Are you sure you want to delete the room %@?";
+"Add an element" = "Add an element";
+"Please enter details:" = "Please enter details:";
+"Are you sure you want to delete the stuff?" = "Are you sure you want to delete the stuff?";
+"Error adding stuff: %@" = "Error adding stuff: %@";
+"Analyze Room" = "Analyze Room";
+
+"Messaging features will be available soon!" = "Messaging features will be available soon!";
+"No property associated." = "No property associated.";
+"No properties available" = "No properties available";
+"Unknown" = "Unknown";
+"Error refreshing damages: %@" = "Error refreshing damages: %@";

--- a/Code/Mobile_iOS/Keyz/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Code/Mobile_iOS/Keyz/Sources/Resources/fr.lproj/Localizable.strings
@@ -174,3 +174,31 @@
 "Low_damage" = "Faible(s)";
 
 "No documents available" = "Aucun document disponible";
+
+"Room Type" = "Type de pièce";
+"Inventory Report" = "État des lieux";
+"Image(s)" = "Image(s)";
+"Property or old report not found. Please check the property details." = "Propriété ou ancien rapport non trouvé. Veuillez vérifier les détails de la propriété.";
+"No previous inventory report found for comparison." = "Aucun rapport d'inventaire précédent trouvé pour la comparaison.";
+
+"Room Analysis" = "Analyse de la pièce";
+"Select room status" = "Sélectionner l'état de la pièce";
+"Send Room Report" = "Envoyer le rapport de la pièce";
+"Broken" = "Cassé";
+"Bad" = "Mauvais";
+"Good" = "Bon";
+"New" = "Neuf";
+
+"Choose a name and type for your new room:" = "Choisissez un nom et un type pour votre nouvelle pièce :";
+"Are you sure you want to delete the room %@" = "Êtes-vous sûr de vouloir supprimer la pièce %@ ?";
+"Add an element" = "Ajouter un élément";
+"Please enter details:" = "Veuillez entrer les détails :";
+"Are you sure you want to delete the stuff?" = "Êtes-vous sûr de vouloir supprimer l'élément ?";
+"Error adding stuff: %@" = "Erreur lors de l'ajout de l'élément : %@";
+"Analyze Room" = "Analyser la pièce";
+
+"Messaging features will be available soon!" = "Les fonctionnalités de messagerie seront bientôt disponibles !";
+"No property associated." = "Aucune propriété associée.";
+"No properties available" = "Aucune propriété disponible";
+"Unknown" = "Inconnu";
+"Error refreshing damages: %@" = "Erreur lors de l'actualisation des sinistres : %@";

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryEvaluationView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryEvaluationView.swift
@@ -12,6 +12,7 @@ import Foundation
 struct InventoryEntryEvaluationView: View {
     @EnvironmentObject var inventoryViewModel: InventoryViewModel
     @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
     let selectedStuff: LocalInventory
 
     @State private var showSheet = false
@@ -31,7 +32,23 @@ struct InventoryEntryEvaluationView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            TopBar(title: "État des lieux")
+            TopBar(title: "Inventory Report".localized())
+                .overlay(
+                    HStack {
+                        Button(action: {
+                            dismiss()
+                        }) {
+                            Image(systemName: "chevron.left")
+                                .font(.title3)
+                                .foregroundColor(Color("textColor"))
+                                .frame(width: 40, height: 40)
+                                .background(Color.black.opacity(0.2))
+                                .clipShape(Circle())
+                        }
+                        .padding(.trailing, 16)
+                    },
+                    alignment: .trailing
+                )
 
             ScrollView {
                 Section {
@@ -40,7 +57,7 @@ struct InventoryEntryEvaluationView: View {
 
                 VStack {
                     HStack {
-                        Text("Commentaire")
+                        Text("Comment".localized())
                             .font(.headline)
                         Spacer()
                     }
@@ -57,13 +74,13 @@ struct InventoryEntryEvaluationView: View {
 
                 VStack {
                     HStack {
-                        Text("Statut")
+                        Text("Status".localized())
                             .font(.headline)
                         Spacer()
                     }
                     HStack {
-                        Picker("Selectionner un statut", selection: $inventoryViewModel.selectedStatus) {
-                            Text("Select your equipment status").tag("Select your equipment status")
+                        Picker("Select a status".localized(), selection: $inventoryViewModel.selectedStatus) {
+                            Text("Select your equipment status".localized()).tag("Select your equipment status")
                             ForEach(Array(stateMapping.values), id: \.self) { status in
                                 Text(status).tag(status)
                             }
@@ -89,7 +106,7 @@ struct InventoryEntryEvaluationView: View {
                             await validateReport()
                         }
                     }, label: {
-                        Text("Valider")
+                        Text("Validate".localized())
                             .padding()
                             .frame(maxWidth: .infinity)
                             .background(Color("LightBlue"))
@@ -105,12 +122,22 @@ struct InventoryEntryEvaluationView: View {
                             isLoading = false
                         }
                     }, label: {
-                        Text("Envoyer le rapport")
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                            .background(Color("LightBlue"))
-                            .foregroundColor(.white)
-                            .cornerRadius(10)
+                        ZStack {
+                            if isLoading {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle())
+                                    .tint(.white)
+                            } else {
+                                Text("Send Report".localized())
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(inventoryViewModel.selectedImages.isEmpty ? Color.gray : Color("LightBlue"))
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                        .scaleEffect(isLoading ? 0.95 : 1.0)
+                        .animation(.easeInOut(duration: 0.2), value: isLoading)
                     })
                     .disabled(isLoading || inventoryViewModel.selectedImages.isEmpty)
                     .padding()
@@ -149,19 +176,19 @@ struct InventoryEntryEvaluationView: View {
     private func showImagePickerOptions(replaceIndex: Int?) {
         self.replaceIndex = replaceIndex
 
-        let actionSheet = UIAlertController(title: "Select Image Source", message: nil, preferredStyle: .actionSheet)
+        let actionSheet = UIAlertController(title: "Select Image Source".localized(), message: nil, preferredStyle: .actionSheet)
 
-        actionSheet.addAction(UIAlertAction(title: "Take Photo", style: .default, handler: { _ in
+        actionSheet.addAction(UIAlertAction(title: "Take Photo".localized(), style: .default, handler: { _ in
             self.sourceType = .camera
             self.showSheet.toggle()
         }))
 
-        actionSheet.addAction(UIAlertAction(title: "Choose from Library", style: .default, handler: { _ in
+        actionSheet.addAction(UIAlertAction(title: "Choose from Library".localized(), style: .default, handler: { _ in
             self.sourceType = .photoLibrary
             self.showSheet.toggle()
         }))
 
-        actionSheet.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        actionSheet.addAction(UIAlertAction(title: "Cancel".localized(), style: .cancel, handler: nil))
 
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let rootViewController = windowScene.windows.first?.rootViewController {
@@ -177,19 +204,19 @@ struct InventoryEntryEvaluationView: View {
         } catch let error as NSError {
             switch error.code {
             case 404:
-                errorMessage = "Property or lease not found. Please check the property details."
+                errorMessage = "Property or lease not found. Please check the property details.".localized()
             case 403:
-                errorMessage = "You do not have permission to access this property."
+                errorMessage = "You do not have permission to access this property.".localized()
             case 400:
                 if error.localizedDescription.contains("datauri") {
-                    errorMessage = "Invalid image format. Please ensure all images are valid JPEGs."
+                    errorMessage = "Invalid image format. Please ensure all images are valid JPEGs.".localized()
                 } else {
-                    errorMessage = "Invalid request: \(error.localizedDescription)"
+                    errorMessage = "Invalid request: \(error.localizedDescription)".localized()
                 }
             case 0 where error.localizedDescription.contains("No active lease found"):
-                errorMessage = "No active lease found for this property."
+                errorMessage = "No active lease found for this property.".localized()
             default:
-                errorMessage = "Error: \(error.localizedDescription)"
+                errorMessage = "Error: \(error.localizedDescription)".localized()
             }
             print("Error sending report: \(error.localizedDescription)")
         }
@@ -267,14 +294,14 @@ struct PicturesSegment: View {
         .padding(.top)
         .actionSheet(isPresented: $showImageOptions) {
             ActionSheet(
-                title: Text("Options"),
+                title: Text("Options".localized()),
                 buttons: [
-                    .default(Text("Replace")) {
+                    .default(Text("Replace".localized())) {
                         if let index = selectedImageIndex {
                             showImagePickerOptions(index)
                         }
                     },
-                    .destructive(Text("Delete")) {
+                    .destructive(Text("Delete".localized())) {
                         if let index = selectedImageIndex {
                             selectedImages.remove(at: index)
                         }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryExitEvaluationView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryExitEvaluationView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct InventoryExitEvaluationView: View {
     @EnvironmentObject var inventoryViewModel: InventoryViewModel
     @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
     let selectedStuff: LocalInventory
     @State private var showSheet = false
     @State private var sourceType: UIImagePickerController.SourceType = .photoLibrary
@@ -29,7 +30,23 @@ struct InventoryExitEvaluationView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            TopBar(title: "État des lieux - Sortie")
+            TopBar(title: "Inventory Report".localized())
+                .overlay(
+                    HStack {
+                        Button(action: {
+                            dismiss()
+                        }) {
+                            Image(systemName: "chevron.left")
+                                .font(.title3)
+                                .foregroundColor(Color("textColor"))
+                                .frame(width: 40, height: 40)
+                                .background(Color.black.opacity(0.2))
+                                .clipShape(Circle())
+                        }
+                        .padding(.trailing, 16)
+                    },
+                    alignment: .trailing
+                )
 
             ScrollView {
                 Section {
@@ -38,7 +55,7 @@ struct InventoryExitEvaluationView: View {
 
                 VStack {
                     HStack {
-                        Text("Commentaire")
+                        Text("Comment".localized())
                             .font(.headline)
                         Spacer()
                     }
@@ -55,13 +72,13 @@ struct InventoryExitEvaluationView: View {
 
                 VStack {
                     HStack {
-                        Text("Statut")
+                        Text("Status".localized())
                             .font(.headline)
                         Spacer()
                     }
                     HStack {
-                        Picker("Selectionner un statut", selection: $inventoryViewModel.selectedStatus) {
-                            Text("Select your equipment status").tag("Select your equipment status")
+                        Picker("Select a status".localized(), selection: $inventoryViewModel.selectedStatus) {
+                            Text("Select your equipment status".localized()).tag("Select your equipment status")
                             ForEach(Array(stateMapping.values), id: \.self) { status in
                                 Text(status).tag(status)
                             }
@@ -86,7 +103,7 @@ struct InventoryExitEvaluationView: View {
                             await validateReport()
                         }
                     }, label: {
-                        Text("Valider")
+                        Text("Validate".localized())
                             .padding()
                             .frame(maxWidth: .infinity)
                             .background(Color("LightBlue"))
@@ -102,12 +119,22 @@ struct InventoryExitEvaluationView: View {
                             isLoading = false
                         }
                     }, label: {
-                        Text("Envoyer le rapport")
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                            .background(Color("LightBlue"))
-                            .foregroundColor(.white)
-                            .cornerRadius(10)
+                        ZStack {
+                            if isLoading {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle())
+                                    .tint(.white)
+                            } else {
+                                Text("Send Report".localized())
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(inventoryViewModel.selectedImages.isEmpty ? Color.gray : Color("LightBlue"))
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                        .scaleEffect(isLoading ? 0.95 : 1.0)
+                        .animation(.easeInOut(duration: 0.2), value: isLoading)
                     })
                     .disabled(isLoading || inventoryViewModel.selectedImages.isEmpty)
                     .padding()
@@ -145,16 +172,16 @@ struct InventoryExitEvaluationView: View {
 
     private func showImagePickerOptions(replaceIndex: Int?) {
         self.replaceIndex = replaceIndex
-        let actionSheet = UIAlertController(title: "Select Image Source", message: nil, preferredStyle: .actionSheet)
-        actionSheet.addAction(UIAlertAction(title: "Take Photo", style: .default, handler: { _ in
+        let actionSheet = UIAlertController(title: "Select Image Source".localized(), message: nil, preferredStyle: .actionSheet)
+        actionSheet.addAction(UIAlertAction(title: "Take Photo".localized(), style: .default, handler: { _ in
             self.sourceType = .camera
             self.showSheet.toggle()
         }))
-        actionSheet.addAction(UIAlertAction(title: "Choose from Library", style: .default, handler: { _ in
+        actionSheet.addAction(UIAlertAction(title: "Choose from Library".localized(), style: .default, handler: { _ in
             self.sourceType = .photoLibrary
             self.showSheet.toggle()
         }))
-        actionSheet.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        actionSheet.addAction(UIAlertAction(title: "Cancel".localized(), style: .cancel, handler: nil))
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let rootViewController = windowScene.windows.first?.rootViewController {
             rootViewController.present(actionSheet, animated: true, completion: nil)
@@ -169,24 +196,24 @@ struct InventoryExitEvaluationView: View {
                 try await inventoryViewModel.compareStuffReport(oldReportId: oldReportId)
                 isReportSent = true
             } else {
-                errorMessage = "No previous inventory report found for comparison."
+                errorMessage = "No previous inventory report found for comparison.".localized()
             }
         } catch let error as NSError {
             switch error.code {
             case 404:
-                errorMessage = "Property or old report not found. Please check the property details."
+                errorMessage = "Property or old report not found. Please check the property details.".localized()
             case 403:
-                errorMessage = "You do not have permission to access this property."
+                errorMessage = "You do not have permission to access this property.".localized()
             case 400:
                 if error.localizedDescription.contains("datauri") {
-                    errorMessage = "Invalid image format. Please ensure all images are valid JPEGs."
+                    errorMessage = "Invalid image format. Please ensure all images are valid JPEGs.".localized()
                 } else {
                     errorMessage = "Invalid request: \(error.localizedDescription)"
                 }
             case 0 where error.localizedDescription.contains("No active lease found"):
-                errorMessage = "No active lease found for this property."
+                errorMessage = "No active lease found for this property.".localized()
             default:
-                errorMessage = "Error: \(error.localizedDescription)"
+                errorMessage = "Error: \(error.localizedDescription)".localized()
             }
             print("Error sending comparison report: \(error.localizedDescription)")
         }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomEvaluationView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomEvaluationView.swift
@@ -30,8 +30,23 @@ struct InventoryRoomEvaluationView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            TopBar(title: "Room Analysis")
-
+            TopBar(title: "Room Analysis".localized())
+                .overlay(
+                    HStack {
+                        Button(action: {
+                            dismiss()
+                        }) {
+                            Image(systemName: "chevron.left")
+                                .font(.title3)
+                                .foregroundColor(Color("textColor"))
+                                .frame(width: 40, height: 40)
+                                .background(Color.black.opacity(0.2))
+                                .clipShape(Circle())
+                        }
+                        .padding(.trailing, 16)
+                    },
+                    alignment: .trailing
+                )
             ScrollView {
                 Section {
                     PicturesSegment(selectedImages: $inventoryViewModel.selectedImages, showImagePickerOptions: showImagePickerOptions)
@@ -39,7 +54,7 @@ struct InventoryRoomEvaluationView: View {
 
                 VStack {
                     HStack {
-                        Text("Comment")
+                        Text("Comment".localized())
                             .font(.headline)
                         Spacer()
                     }
@@ -56,7 +71,7 @@ struct InventoryRoomEvaluationView: View {
 
                 VStack {
                     HStack {
-                        Text("Status")
+                        Text("Status".localized())
                             .font(.headline)
                         Spacer()
                     }
@@ -104,12 +119,22 @@ struct InventoryRoomEvaluationView: View {
                             isLoading = false
                         }
                     }, label: {
-                        Text("Send Room Report".localized())
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                            .background(Color("LightBlue"))
-                            .foregroundColor(.white)
-                            .cornerRadius(10)
+                        ZStack {
+                            if isLoading {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle())
+                                    .tint(.white)
+                            } else {
+                                Text("Send Room Report".localized())
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(inventoryViewModel.selectedImages.isEmpty ? Color.gray : Color("LightBlue"))
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                        .scaleEffect(isLoading ? 0.95 : 1.0)
+                        .animation(.easeInOut(duration: 0.2), value: isLoading)
                     })
                     .disabled(isLoading || inventoryViewModel.selectedImages.isEmpty)
                     .padding()
@@ -151,19 +176,19 @@ struct InventoryRoomEvaluationView: View {
     private func showImagePickerOptions(replaceIndex: Int?) {
         self.replaceIndex = replaceIndex
 
-        let actionSheet = UIAlertController(title: "Select Image Source", message: nil, preferredStyle: .actionSheet)
+        let actionSheet = UIAlertController(title: "Select Image Source".localized(), message: nil, preferredStyle: .actionSheet)
 
-        actionSheet.addAction(UIAlertAction(title: "Take Photo", style: .default, handler: { _ in
+        actionSheet.addAction(UIAlertAction(title: "Take Photo".localized(), style: .default, handler: { _ in
             self.sourceType = .camera
             self.showSheet.toggle()
         }))
 
-        actionSheet.addAction(UIAlertAction(title: "Choose from Library", style: .default, handler: { _ in
+        actionSheet.addAction(UIAlertAction(title: "Choose from Library".localized(), style: .default, handler: { _ in
             self.sourceType = .photoLibrary
             self.showSheet.toggle()
         }))
 
-        actionSheet.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        actionSheet.addAction(UIAlertAction(title: "Cancel".localized(), style: .cancel, handler: nil))
 
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let rootViewController = windowScene.windows.first?.rootViewController {
@@ -185,7 +210,7 @@ struct InventoryRoomEvaluationView: View {
                 if error.localizedDescription.contains("datauri") {
                     errorMessage = "Invalid image format. Please ensure all images are valid JPEGs.".localized()
                 } else {
-                    errorMessage = "Invalid request: \(error.localizedDescription)"
+                    errorMessage = "Invalid request: \(error.localizedDescription)".localized()
                 }
             case 0 where error.localizedDescription.contains("No active lease found"):
                 errorMessage = "No active lease found for this property.".localized()

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomExitEvaluationView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomExitEvaluationView.swift
@@ -30,8 +30,23 @@ struct InventoryRoomExitEvaluationView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            TopBar(title: "Room Analysis - Exit".localized())
-
+            TopBar(title: "Room Analysis".localized())
+                .overlay(
+                    HStack {
+                        Button(action: {
+                            dismiss()
+                        }) {
+                            Image(systemName: "chevron.left")
+                                .font(.title3)
+                                .foregroundColor(Color("textColor"))
+                                .frame(width: 40, height: 40)
+                                .background(Color.black.opacity(0.2))
+                                .clipShape(Circle())
+                        }
+                        .padding(.trailing, 16)
+                    },
+                    alignment: .trailing
+                )
             ScrollView {
                 Section {
                     PicturesSegment(selectedImages: $inventoryViewModel.selectedImages, showImagePickerOptions: showImageSelection)
@@ -104,12 +119,22 @@ struct InventoryRoomExitEvaluationView: View {
                             isLoading = false
                         }
                     }, label: {
-                        Text("Send Room Report".localized())
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                            .background(Color("LightBlue"))
-                            .foregroundColor(.white)
-                            .cornerRadius(10)
+                        ZStack {
+                            if isLoading {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle())
+                                    .tint(.white)
+                            } else {
+                                Text("Send Room Report".localized())
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(inventoryViewModel.selectedImages.isEmpty ? Color.gray : Color("LightBlue"))
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                        .scaleEffect(isLoading ? 0.95 : 1.0)
+                        .animation(.easeInOut(duration: 0.2), value: isLoading)
                     })
                     .disabled(isLoading || inventoryViewModel.selectedImages.isEmpty)
                     .padding()

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomView.swift
@@ -16,6 +16,22 @@ struct InventoryRoomView: View {
         ZStack {
             VStack(spacing: 0) {
                 TopBar(title: "Keyz")
+                    .overlay(
+                        HStack {
+                            Button(action: {
+                                dismiss()
+                            }) {
+                                Image(systemName: "chevron.left")
+                                    .font(.title3)
+                                    .foregroundColor(Color("textColor"))
+                                    .frame(width: 40, height: 40)
+                                    .background(Color.black.opacity(0.2))
+                                    .clipShape(Circle())
+                            }
+                            .padding(.trailing, 16)
+                        },
+                        alignment: .trailing
+                    )
                 VStack {
                     Spacer()
                     RoomListView(showDeleteConfirmationAlert: $showDeleteConfirmationAlert, roomToDelete: $roomToDelete)

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryStuffView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryStuffView.swift
@@ -55,6 +55,22 @@ struct InventoryStuffView: View {
     private var contentView: some View {
         VStack(spacing: 0) {
             TopBar(title: "Keyz")
+                .overlay(
+                    HStack {
+                        Button(action: {
+                            dismiss()
+                        }) {
+                            Image(systemName: "chevron.left")
+                                .font(.title3)
+                                .foregroundColor(Color("textColor"))
+                                .frame(width: 40, height: 40)
+                                .background(Color.black.opacity(0.2))
+                                .clipShape(Circle())
+                        }
+                        .padding(.trailing, 16)
+                    },
+                    alignment: .trailing
+                )
             if let selectedRoom = selectedRoom {
                 VStack {
                     Spacer()

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Messages/MessagesView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Messages/MessagesView.swift
@@ -14,6 +14,7 @@ struct MessagesView: View {
                 TopBar(title: "Keyz".localized())
                 Spacer()
                 Text("Messaging features will be available soon!".localized())
+                    .foregroundStyle(.gray)
                 Spacer()
             }
             .navigationBarBackButtonHidden(true)

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Overview/OverviewView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Overview/OverviewView.swift
@@ -15,6 +15,8 @@ struct OverviewView: View {
     @State private var navigateToDamage: (propertyId: String, damageId: String)? = nil
     @State private var showError = false
     @State private var errorMessage: String?
+    @State private var navigateToReportDamage: Bool = false
+    @State private var navigateToInventory: Bool = false
 
     init() {
         self._viewModel = StateObject(wrappedValue: OverviewViewModel())
@@ -77,7 +79,9 @@ struct OverviewView: View {
                 if let property = navigateToProperty {
                     PropertyDetailView(
                         property: property,
-                        viewModel: PropertyViewModel(loginViewModel: loginViewModel)
+                        viewModel: PropertyViewModel(loginViewModel: loginViewModel),
+                        navigateToReportDamage: $navigateToReportDamage,
+                        navigateToInventory: $navigateToInventory
                     )
                     .environmentObject(loginViewModel)
                 }
@@ -110,7 +114,9 @@ struct OverviewView: View {
                             rooms: [],
                             damages: []
                         ),
-                        viewModel: PropertyViewModel(loginViewModel: loginViewModel)
+                        viewModel: PropertyViewModel(loginViewModel: loginViewModel),
+                        navigateToReportDamage: $navigateToReportDamage,
+                        navigateToInventory: $navigateToInventory
                     )
                     .environmentObject(loginViewModel)
                 }
@@ -118,7 +124,9 @@ struct OverviewView: View {
             .onAppear {
                 loginViewModel.loadUser()
                 Task {
-                    await viewModel.fetchDashboardData()
+                    if loginViewModel.userRole == "owner" {                        
+                        await viewModel.fetchDashboardData()
+                    }
                 }
             }
             .onChange(of: viewModel.errorMessage) {

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyDetailView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyDetailView.swift
@@ -194,6 +194,8 @@ struct PropertyDetailView: View {
                     }
                 }
             }
+
+
             .sheet(isPresented: $showEditPropertyPopUp) {
                 EditPropertyView(viewModel: viewModel, property: $property)
             }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyDetailView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyDetailView.swift
@@ -19,22 +19,29 @@ struct PropertyDetailView: View {
     @State private var showCancelInvitePopUp = false
     @State private var showDeletePropertyPopUp = false
     @State private var showEditPropertyPopUp = false
-    @State private var navigateToReportDamage = false
+    @Binding private var navigateToReportDamage: Bool
     @State private var errorMessage: String?
     @State private var isLoading = false
     @State private var selectedTab: String = "Details".localized()
     @State private var isEntryInventory: Bool = true
-    @State private var navigateToInventory: Bool = false
+    @Binding private var navigateToInventory: Bool
     @State private var rooms: [PropertyRoomsTenant] = []
     @State private var activeLeaseId: String?
     @State private var hasLoaded = false
     @Environment(\.dismiss) var dismiss
     private let tabs = ["Details".localized(), "Documents".localized(), "Damages".localized()]
     
-    init(property: Property, viewModel: PropertyViewModel) {
+    init(
+        property: Property,
+        viewModel: PropertyViewModel,
+        navigateToReportDamage: Binding<Bool>,
+        navigateToInventory: Binding<Bool>
+    ) {
         self._property = State(initialValue: property)
         self.viewModel = viewModel
         self._inventoryViewModel = StateObject(wrappedValue: InventoryViewModel(property: property))
+        self._navigateToReportDamage = navigateToReportDamage
+        self._navigateToInventory = navigateToInventory
     }
 
     private func fetchDocuments() async {
@@ -116,7 +123,6 @@ struct PropertyDetailView: View {
     }
     
     var body: some View {
-        NavigationStack {
             ZStack {
                 mainContentView
                 errorMessageView
@@ -142,37 +148,14 @@ struct PropertyDetailView: View {
                     .padding(.trailing, 20)
                 }
             }
+            .navigationBarBackButtonHidden(true)
             .onReceive(viewModel.$properties) { properties in
                 if let updatedProperty = properties.first(where: { $0.id == property.id }) {
-                    if !updatedProperty.documents.isEmpty {
+                    if !updatedProperty.documents.isEmpty || updatedProperty.isAvailable != property.isAvailable {
                         self.property = updatedProperty
                     }
                 }
             }
-            .navigationDestination(isPresented: $navigateToReportDamage) {
-                ReportDamageView(
-                    viewModel: viewModel,
-                    propertyId: property.id,
-                    rooms: rooms,
-                    leaseId: activeLeaseId,
-                    onDamageCreated: {
-                        Task {
-                            do {
-                                try await viewModel.fetchPropertyDamages(propertyId: property.id)
-                            } catch {
-                                await MainActor.run {
-                                    self.errorMessage = "Error refreshing damages: \(error.localizedDescription)".localized()
-                                }
-                            }
-                        }
-                    }
-                )
-            }
-            .navigationDestination(isPresented: $navigateToInventory) {
-                InventoryRoomView()
-                    .environmentObject(inventoryViewModel)
-            }
-            .navigationBarBackButtonHidden(true)
             .onAppear {
                 guard !hasLoaded else { return }
                 hasLoaded = true
@@ -194,8 +177,6 @@ struct PropertyDetailView: View {
                     }
                 }
             }
-
-
             .sheet(isPresented: $showEditPropertyPopUp) {
                 EditPropertyView(viewModel: viewModel, property: $property)
             }
@@ -203,7 +184,10 @@ struct PropertyDetailView: View {
                 InviteTenantView(tenantViewModel: tenantViewModel, property: property)
             }
             .overlay(alertsView)
-        }
+            .navigationDestination(isPresented: $navigateToInventory) {
+                InventoryRoomView()
+                    .environmentObject(inventoryViewModel)
+            }
     }
     
     private var damagesContentView: some View {
@@ -304,14 +288,20 @@ struct PropertyDetailView: View {
 
     private var optionsMenuView: some View {
         Menu {
-            Button(action: { showInviteTenantSheet = true }) {
-                Label("Invite Tenant".localized(), systemImage: "person.crop.circle.badge.plus")
+            if property.isAvailable == "available" {
+                Button(action: { showInviteTenantSheet = true }) {
+                    Label("Invite Tenant".localized(), systemImage: "person.crop.circle.badge.plus")
+                }
             }
-            Button(action: { showEndLeasePopUp = true }) {
-                Label("End Lease".localized(), systemImage: "xmark.circle")
+            if property.isAvailable == "pending" {
+                Button(action: { showCancelInvitePopUp = true }) {
+                    Label("Cancel Invite".localized(), systemImage: "person.crop.circle.badge.xmark")
+                }
             }
-            Button(action: { showCancelInvitePopUp = true }) {
-                Label("Cancel Invite".localized(), systemImage: "person.crop.circle.badge.xmark")
+            if property.isAvailable == "unavailable" {
+                Button(action: { showEndLeasePopUp = true }) {
+                    Label("End Lease".localized(), systemImage: "xmark.circle")
+                }
             }
             Button(action: { showEditPropertyPopUp = true }) {
                 Label("Edit Property".localized(), systemImage: "pencil")
@@ -339,7 +329,7 @@ struct PropertyDetailView: View {
                     .font(.title2)
                     .fontWeight(.bold)
                     .foregroundColor(Color("textColor"))
-                Text(property.isAvailable == "available" ? "Available".localized() : "Unavailable".localized())
+                Text(statusText)
                     .font(.caption)
                     .fontWeight(.medium)
                     .foregroundColor(.white)
@@ -347,9 +337,9 @@ struct PropertyDetailView: View {
                     .padding(.vertical, 4)
                     .background(
                         RoundedRectangle(cornerRadius: 8)
-                            .fill(property.isAvailable == "available" ? Color("GreenAlert") : Color("RedAlert"))
+                            .fill(statusColor)
                     )
-                    .accessibilityLabel(property.isAvailable == "available" ? "text_available" : "text_unavailable")
+                    .accessibilityLabel(statusAccessibilityLabel)
             }
             HStack(spacing: 4) {
                 Image(systemName: "mappin.and.ellipse.circle")
@@ -363,10 +353,38 @@ struct PropertyDetailView: View {
             }
         }
         .padding(.horizontal)
+        .padding(.bottom, 8)
+    }
+
+    private var statusText: String {
+        switch property.isAvailable {
+        case "available": return "Available".localized()
+        case "pending": return "Pending".localized()
+        case "unavailable": return "Unavailable".localized()
+        default: return "Unknown".localized()
+        }
+    }
+
+    private var statusColor: Color {
+        switch property.isAvailable {
+        case "available": return Color("GreenAlert")
+        case "pending": return Color.orange
+        case "unavailable": return Color("RedAlert")
+        default: return Color.gray
+        }
+    }
+
+    private var statusAccessibilityLabel: String {
+        switch property.isAvailable {
+        case "available": return "text_available"
+        case "pending": return "text_pending"
+        case "unavailable": return "text_unavailable"
+        default: return "text_unknown"
+        }
     }
 
     private var tabsView: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 20) {
             ForEach(tabs, id: \.self) { tab in
                 Button(action: {
                     withAnimation(.easeInOut(duration: 0.3)) {
@@ -479,12 +497,13 @@ struct PropertyDetailView: View {
                         Text(isEntryInventory ? "Start Entry Inventory".localized() : "Start Exit Inventory".localized())
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 15)
-                            .background(Color("LightBlue"))
+                            .background(property.leaseId == nil ? Color.gray : Color("LightBlue"))
                             .foregroundColor(.white)
                             .cornerRadius(10)
                             .padding(.horizontal)
                             .padding(.bottom, 10)
                     }
+                    .disabled(property.leaseId == nil)
                     .accessibilityLabel(isEntryInventory ? "inventory_btn_entry" : "inventory_btn_exit")
                 }
             }
@@ -628,6 +647,9 @@ struct PropertyDetailView: View {
 }
 
 struct PropertyDetailView_Previews: PreviewProvider {
+    @State static var navigateToReportDamage: Bool = false
+    @State static var navigateToInventory: Bool = false
+    
     static var previews: some View {
         let property = Property(
             id: "",
@@ -731,8 +753,14 @@ struct PropertyDetailView_Previews: PreviewProvider {
         let viewModel = PropertyViewModel(loginViewModel: LoginViewModel())
         let loginViewModel = LoginViewModel()
         
-        return PropertyDetailView(property: property, viewModel: viewModel)
-            .environmentObject(viewModel)
-            .environmentObject(loginViewModel)
+        return PropertyDetailView(
+            property: property,
+            viewModel: viewModel,
+            navigateToReportDamage: $navigateToReportDamage,
+            navigateToInventory: $navigateToInventory
+        )
+        .environmentObject(viewModel)
+        .environmentObject(loginViewModel)
     }
 }
+

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyViewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyViewModel.swift
@@ -88,7 +88,6 @@ class PropertyViewModel: ObservableObject {
                 documents = try await tenantViewModel.fetchTenantPropertyDocuments(leaseId: leaseId, propertyId: propertyId)
             } else {
                 documents = []
-//                throw NSError(domain: "", code: 404, userInfo: [NSLocalizedDescriptionKey: "No active lease found.".localized()])
             }
         } else {
             documents = try await ownerViewModel.fetchPropertyDocuments(propertyId: propertyId)

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/TenantViewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/TenantViewModel.swift
@@ -22,25 +22,11 @@ class TenantViewModel: ObservableObject {
         }
     }
     
-    struct InviteResponse: Codable {
+    struct InviteIDResponse: Codable {
         let id: String
-        let tenantEmail: String
-        let propertyId: String
-        let createdAt: String
-        let startDate: String
-        let endDate: String?
-        
-        enum CodingKeys: String, CodingKey {
-            case id
-            case tenantEmail = "tenant_email"
-            case propertyId = "property_id"
-            case createdAt = "created_at"
-            case startDate = "start_date"
-            case endDate = "end_date"
-        }
     }
     
-    func inviteTenant(propertyId: String, email: String, startDate: Date, endDate: Date? = nil) async throws -> InviteResponse {
+    func inviteTenant(propertyId: String, email: String, startDate: Date, endDate: Date? = nil) async throws -> String {
         let endpoint = "owner/properties/\(propertyId)/send-invite/"
         let url = URL(string: "\(APIConfig.baseURL)/\(endpoint)")!
         var request = URLRequest(url: url)
@@ -71,8 +57,8 @@ class TenantViewModel: ObservableObject {
         
         switch httpResponse.statusCode {
         case 201:
-            let inviteResponse = try JSONDecoder().decode(InviteResponse.self, from: data)
-            return inviteResponse
+            let inviteResponse = try JSONDecoder().decode(InviteIDResponse.self, from: data)
+            return inviteResponse.id
         case 400:
             throw NSError(domain: "", code: 400, userInfo: [NSLocalizedDescriptionKey: "Missing fields"])
         case 403:

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/ViewModels/OwnerPropertyViewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/ViewModels/OwnerPropertyViewModel.swift
@@ -143,6 +143,7 @@ class OwnerPropertyViewModel: ObservableObject {
         
         self.properties = propertiesData.map { propertyResponse in
             let existingProperty = properties.first(where: { $0.id == propertyResponse.id })
+            let status = propertyResponse.isAvailable == "invite sent" ? "pending" : propertyResponse.isAvailable
             return Property(
                 id: propertyResponse.id,
                 ownerID: propertyResponse.ownerId,
@@ -155,7 +156,7 @@ class OwnerPropertyViewModel: ObservableObject {
                 monthlyRent: propertyResponse.rentalPricePerMonth,
                 deposit: propertyResponse.depositPrice,
                 surface: propertyResponse.areaSqm,
-                isAvailable: propertyResponse.isAvailable,
+                isAvailable: status,
                 tenantName: propertyResponse.lease?.tenantName,
                 leaseId: propertyResponse.lease?.id,
                 leaseStartDate: propertyResponse.lease?.startDate,

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Register/RegisterView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Register/RegisterView.swift
@@ -19,7 +19,7 @@ struct RegisterView: View {
                         .font(.system(size: 25))
                         .bold()
                         .padding(.bottom, 5)
-                    Text("Join Immotep for your peace of mind!".localized())
+                    Text("Join Keyz for your peace of mind!".localized())
                         .font(.system(size: 14))
                         .padding(.bottom, 50)
 
@@ -90,7 +90,7 @@ struct RegisterView: View {
                         .resizable()
                         .frame(width: 50, height: 50)
                         .padding(.bottom, 40)
-                    Text("Immotep".localized())
+                    Text("Keyz")
                         .font(.title)
                         .bold()
                         .padding(.bottom, 40)


### PR DESCRIPTION
Fixed following bugs in iOS app:
- Fixed popup animation being too long, which could cause issues when the user interacts too quickly
- Start inventory button is now disabled when no lease is associated
- Fixed keyboard overlapping the popups for adding rooms or furnitures
- PropertyDetailsView: fixed access conditions for tenant invitation and cancellation actions
- Fixed visual feedback on IA report buttons (no longer looks unresponsive)
- Fixed tenant invitation feature (was not working consistently)
- Status 'pending' after invitation now displays correctly
- After register, a success message is now shown

Other minor improvements have been made:
- Missing translations added on some popups and error messages
- Back button added on inventory views