### PR TITLE
feat/ios-app - Add Document Upload/Delete Functionality & API call optimization

### DIFF
--- a/Code/Mobile_iOS/Keyz/Sources/Utils/Debouncer.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Utils/Debouncer.swift
@@ -1,0 +1,24 @@
+//
+//  Debouncer.swift
+//  Keyz
+//
+//  Created by Liebenguth Alessio on 22/06/2025.
+//
+
+import SwiftUI
+
+class Debouncer {
+    private let delay: TimeInterval
+    private var workItem: DispatchWorkItem?
+
+    init(delay: TimeInterval) {
+        self.delay = delay
+    }
+
+    func debounce(_ block: @escaping () -> Void) {
+        workItem?.cancel()
+        let newWorkItem = DispatchWorkItem(block: block)
+        workItem = newWorkItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: newWorkItem)
+    }
+}

--- a/Code/Mobile_iOS/Keyz/Sources/Utils/ImageCache.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Utils/ImageCache.swift
@@ -1,0 +1,34 @@
+//
+//  ImageCache.swift
+//  Keyz
+//
+//  Created by Liebenguth Alessio on 22/06/2025.
+//
+
+import SwiftUI
+
+class ImageCache {
+    static let shared = ImageCache()
+    private var cache: [String: UIImage] = [:]
+    private let lock = NSLock()
+
+    private init() {}
+
+    func getImage(forKey key: String) -> UIImage? {
+        lock.lock()
+        defer { lock.unlock() }
+        return cache[key]
+    }
+
+    func setImage(_ image: UIImage?, forKey key: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        cache[key] = image
+    }
+
+    func clearCache() {
+        lock.lock()
+        defer { lock.unlock() }
+        cache.removeAll()
+    }
+}

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomEvaluationView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomEvaluationView.swift
@@ -21,7 +21,7 @@ struct InventoryRoomEvaluationView: View {
     @State private var isReportSent: Bool = false
 
     let stateMapping: [String: String] = [
-        "not_set": "Select your equipment status",
+        "not_set": "Select your room status",
         "broken": "Broken",
         "needsRepair": "Needs Repair",
         "bad": "Bad",

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomExitEvaluationView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Inventory/InventoryRoomExitEvaluationView.swift
@@ -21,7 +21,7 @@ struct InventoryRoomExitEvaluationView: View {
     @State private var isReportSent: Bool = false
 
     let stateMapping: [String: String] = [
-        "not_set": "Select your equipment status",
+        "not_set": "Select your room status",
         "broken": "Broken",
         "needsRepair": "Needs Repair",
         "bad": "Bad",

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Overview/OverviewView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Overview/OverviewView.swift
@@ -11,7 +11,7 @@ struct OverviewView: View {
     @EnvironmentObject private var loginViewModel: LoginViewModel
     @StateObject private var viewModel: OverviewViewModel
     @AppStorage("isLoggedIn") var isLoggedIn: Bool = false
-    @State private var navigateToProperty: Property? = nil
+    @State private var navigateToProperty: String? = nil
     @State private var navigateToDamage: (propertyId: String, damageId: String)? = nil
     @State private var showError = false
     @State private var errorMessage: String?
@@ -76,9 +76,9 @@ struct OverviewView: View {
                 get: { navigateToProperty != nil },
                 set: { if !$0 { navigateToProperty = nil } }
             )) {
-                if let property = navigateToProperty {
+                if let propertyId = navigateToProperty {
                     PropertyDetailView(
-                        property: property,
+                        propertyId: propertyId,
                         viewModel: PropertyViewModel(loginViewModel: loginViewModel),
                         navigateToReportDamage: $navigateToReportDamage,
                         navigateToInventory: $navigateToInventory
@@ -92,28 +92,7 @@ struct OverviewView: View {
             )) {
                 if let damage = navigateToDamage {
                     PropertyDetailView(
-                        property: Property(
-                            id: damage.propertyId,
-                            ownerID: "",
-                            name: "",
-                            address: "",
-                            city: "",
-                            postalCode: "",
-                            country: "",
-                            photo: nil,
-                            monthlyRent: 0,
-                            deposit: 0,
-                            surface: 0,
-                            isAvailable: "",
-                            tenantName: nil,
-                            leaseId: nil,
-                            leaseStartDate: nil,
-                            leaseEndDate: nil,
-                            documents: [],
-                            createdAt: "",
-                            rooms: [],
-                            damages: []
-                        ),
+                        propertyId: damage.propertyId,
                         viewModel: PropertyViewModel(loginViewModel: loginViewModel),
                         navigateToReportDamage: $navigateToReportDamage,
                         navigateToInventory: $navigateToInventory
@@ -124,7 +103,7 @@ struct OverviewView: View {
             .onAppear {
                 loginViewModel.loadUser()
                 Task {
-                    if loginViewModel.userRole == "owner" {                        
+                    if loginViewModel.userRole == "owner" {
                         await viewModel.fetchDashboardData()
                     }
                 }
@@ -166,7 +145,7 @@ struct WelcomeWidget: View {
 struct RemindersWidget: View {
     let reminders: [Reminder]
     let properties: PropertyStats
-    @Binding var navigateToProperty: Property?
+    @Binding var navigateToProperty: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -188,29 +167,8 @@ struct RemindersWidget: View {
                 ForEach(reminders.prefix(3)) { reminder in
                     Button(action: {
                         if let components = parseLink(reminder.link),
-                           let property = properties.recentlyAdded?.first(where: { $0.id == components.propertyId }) {
-                            navigateToProperty = Property(
-                                id: property.id,
-                                ownerID: property.ownerId,
-                                name: property.name,
-                                address: property.address,
-                                city: property.city,
-                                postalCode: property.postalCode,
-                                country: property.country,
-                                photo: nil,
-                                monthlyRent: property.rentalPricePerMonth,
-                                deposit: property.depositPrice,
-                                surface: property.areaSqm,
-                                isAvailable: property.archived ? "archived" : (properties.available > 0 ? "available" : "occupied"),
-                                tenantName: nil,
-                                leaseId: nil,
-                                leaseStartDate: nil,
-                                leaseEndDate: nil,
-                                documents: [],
-                                createdAt: property.createdAt,
-                                rooms: [],
-                                damages: []
-                            )
+                           properties.recentlyAdded?.first(where: { $0.id == components.propertyId }) != nil {
+                            navigateToProperty = components.propertyId
                         }
                     }) {
                         ReminderItem(reminder: reminder)
@@ -279,7 +237,7 @@ struct ReminderItem: View {
 
 struct PropertiesWidget: View {
     let stats: PropertyStats
-    @Binding var navigateToProperty: Property?
+    @Binding var navigateToProperty: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -308,28 +266,7 @@ struct PropertiesWidget: View {
 
             if let recentProperty = stats.recentlyAdded?.first {
                 Button(action: {
-                    navigateToProperty = Property(
-                        id: recentProperty.id,
-                        ownerID: recentProperty.ownerId,
-                        name: recentProperty.name,
-                        address: recentProperty.address,
-                        city: recentProperty.city,
-                        postalCode: recentProperty.postalCode,
-                        country: recentProperty.country,
-                        photo: nil,
-                        monthlyRent: recentProperty.rentalPricePerMonth,
-                        deposit: recentProperty.depositPrice,
-                        surface: recentProperty.areaSqm,
-                        isAvailable: recentProperty.archived ? "archived" : (stats.available > 0 ? "available" : "occupied"),
-                        tenantName: nil,
-                        leaseId: nil,
-                        leaseStartDate: nil,
-                        leaseEndDate: nil,
-                        documents: [],
-                        createdAt: recentProperty.createdAt,
-                        rooms: [],
-                        damages: []
-                    )
+                    navigateToProperty = recentProperty.id
                 }) {
                     PropertyItem(property: recentProperty)
                 }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/EditPropertyView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/EditPropertyView.swift
@@ -168,6 +168,7 @@ struct EditPropertyView: View {
             let propertyId = try await viewModel.updateProperty(request: updatedProperty, token: token)
 
             if let newPhoto = photo, newPhoto != property.photo {
+                ImageCache.shared.setImage(nil, forKey: propertyId)
                 do {
                     let _ = try await viewModel.updatePropertyPicture(token: token, propertyPicture: newPhoto, propertyID: propertyId)
                 } catch {

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyDetailView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyDetailView.swift
@@ -7,9 +7,10 @@
 
 import SwiftUI
 import PDFKit
+import UniformTypeIdentifiers
+import MobileCoreServices
 
 struct PropertyDetailView: View {
-    @State private var property: Property
     @ObservedObject var viewModel: PropertyViewModel
     @EnvironmentObject var loginViewModel: LoginViewModel
     @StateObject private var tenantViewModel = TenantViewModel()
@@ -22,6 +23,7 @@ struct PropertyDetailView: View {
     @Binding private var navigateToReportDamage: Bool
     @State private var errorMessage: String?
     @State private var isLoading = false
+    @State private var isImageLoading = false
     @State private var selectedTab: String = "Details".localized()
     @State private var isEntryInventory: Bool = true
     @Binding private var navigateToInventory: Bool
@@ -29,135 +31,183 @@ struct PropertyDetailView: View {
     @State private var activeLeaseId: String?
     @State private var hasLoaded = false
     @Environment(\.dismiss) var dismiss
-    @State private var damageFilter: Bool? = false
-    @State private var selectedDamageId: String? = nil
+    @State private var damageFilter: Bool = false
+    @State private var selectedDamageId: String?
+    @State private var showDocumentPicker = false
     private let tabs = ["Details".localized(), "Documents".localized(), "Damages".localized()]
-    
+    let propertyId: String
+    private let debouncer = Debouncer(delay: 0.5)
+
     init(
-        property: Property,
+        propertyId: String,
         viewModel: PropertyViewModel,
         navigateToReportDamage: Binding<Bool>,
         navigateToInventory: Binding<Bool>
     ) {
-        self._property = State(initialValue: property)
+        self.propertyId = propertyId
         self.viewModel = viewModel
-        self._inventoryViewModel = StateObject(wrappedValue: InventoryViewModel(property: property))
+        self._inventoryViewModel = StateObject(wrappedValue: InventoryViewModel(property: viewModel.properties.first(where: { $0.id == propertyId }) ?? Property(id: "", ownerID: "", name: "", address: "", city: "", postalCode: "", country: "", photo: nil, monthlyRent: 0, deposit: 0, surface: 0, isAvailable: "", tenantName: nil, leaseId: nil, leaseStartDate: nil, leaseEndDate: nil, documents: [], createdAt: "", rooms: [], damages: [])))
         self._navigateToReportDamage = navigateToReportDamage
         self._navigateToInventory = navigateToInventory
     }
 
+    private var property: Property? {
+        viewModel.properties.first(where: { $0.id == propertyId })
+    }
+
+    private var hasActiveLease: Bool {
+        if loginViewModel.userRole == "tenant" {
+            return activeLeaseId != nil
+        } else if loginViewModel.userRole == "owner" {
+            return property?.leaseId != nil
+        }
+        return false
+    }
+
     private func fetchDocuments() async {
+        guard let property = property, property.leaseId != nil else {
+            return
+        }
         do {
-            let fetchedDocuments = try await viewModel.fetchPropertyDocuments(propertyId: property.id)
+            let fetchedDocuments = try await viewModel.fetchPropertyDocuments(propertyId: propertyId)
             await MainActor.run {
-                property.documents = fetchedDocuments
-            }
-            if let index = viewModel.properties.firstIndex(where: { $0.id == property.id }) {
-                var updatedProperty = viewModel.properties[index]
-                updatedProperty.documents = fetchedDocuments
-                viewModel.properties[index] = updatedProperty
+                if let index = viewModel.properties.firstIndex(where: { $0.id == propertyId }) {
+                    var updatedProperty = viewModel.properties[index]
+                    updatedProperty.documents = fetchedDocuments
+                    viewModel.properties[index] = updatedProperty
+                    viewModel.objectWillChange.send()
+                }
             }
         } catch {
-            errorMessage = "Error fetching documents: \(error.localizedDescription)".localized()
+            await MainActor.run {
+                errorMessage = "Error fetching documents: \(error.localizedDescription)".localized()
+            }
         }
     }
-    
+
     private func fetchInitialData() async {
-        do {
-            isLoading = true
-            if property.photo == nil || property.damages.isEmpty {
-                await viewModel.fetchProperties()
-                if let updatedProperty = viewModel.properties.first(where: { $0.id == property.id }) {
-                    property = updatedProperty
-                }
-            }
-            await fetchDocuments()
-            if loginViewModel.userRole == "tenant" {
-                let token = try await TokenStorage.getValidAccessToken()
+        debouncer.debounce {
+            Task {
+                guard let property = property else { return }
                 do {
-                    rooms = try await viewModel.fetchPropertyRooms(propertyId: property.id, token: token)
-                } catch {
-                    errorMessage = "Error fetching rooms: \(error.localizedDescription)".localized()
-                }
-                do {
-                    activeLeaseId = try await viewModel.fetchActiveLeaseIdForProperty(propertyId: property.id, token: token)
-                } catch {
-                    errorMessage = "Error fetching active lease: \(error.localizedDescription)".localized()
-                }
-                if property.damages.isEmpty, activeLeaseId != nil {
-                    do {
-                        try await viewModel.fetchPropertyDamages(propertyId: property.id, fixed: damageFilter)
-                        if let updatedProperty = viewModel.properties.first(where: { $0.id == property.id }) {
-                            property = updatedProperty
+                    isLoading = true
+                    if property.photo == nil {
+                        isImageLoading = true
+                        do {
+                            let image = try await viewModel.fetchPropertiesPicture(propertyId: propertyId)
+                            await MainActor.run {
+                                if let index = viewModel.properties.firstIndex(where: { $0.id == propertyId }) {
+                                    var updatedProperty = viewModel.properties[index]
+                                    updatedProperty.photo = image
+                                    viewModel.properties[index] = updatedProperty
+                                    viewModel.objectWillChange.send()
+                                }
+                            }
+                        } catch {
+                            errorMessage = "Error fetching image: \(error.localizedDescription)".localized()
                         }
-                    } catch {
-                        errorMessage = "Error fetching damages: \(error.localizedDescription)".localized()
+                        isImageLoading = false
                     }
-                }
-            }
-            if loginViewModel.userRole == "owner", let leaseId = property.leaseId {
-                if property.damages.isEmpty {
-                    do {
-                        try await viewModel.fetchPropertyDamages(propertyId: property.id, fixed: damageFilter)
-                        if let updatedProperty = viewModel.properties.first(where: { $0.id == property.id }) {
-                            property = updatedProperty
+
+                    if loginViewModel.userRole == "tenant" {
+                        let token = try await TokenStorage.getValidAccessToken()
+                        do {
+                            rooms = try await viewModel.fetchPropertyRooms(propertyId: propertyId, token: token)
+                        } catch {
+                            errorMessage = "Error fetching rooms: \(error.localizedDescription)".localized()
                         }
-                    } catch {
-                        errorMessage = "Error fetching damages: \(error.localizedDescription)".localized()
+                        do {
+                            activeLeaseId = try await viewModel.fetchActiveLeaseIdForProperty(propertyId: propertyId, token: token)
+                        } catch {
+                            isLoading = false
+                            return
+                        }
+                        if activeLeaseId != nil {
+                            if property.damages.isEmpty {
+                                try await viewModel.fetchPropertyDamages(propertyId: propertyId, fixed: damageFilter)
+                            }
+                            await fetchDocuments()
+                        }
                     }
-                }
-                do {
-                    if let lastReport = try await viewModel.fetchLastInventoryReport(propertyId: property.id, leaseId: leaseId) {
-                        isEntryInventory = lastReport.type == "end" || lastReport.type == "middle"
-                    } else {
-                        isEntryInventory = true
+                    else if loginViewModel.userRole == "owner" {
+                        if let leaseId = property.leaseId {
+                            if property.damages.isEmpty {
+                                try await viewModel.fetchPropertyDamages(propertyId: propertyId, fixed: damageFilter)
+                            }
+                            await fetchDocuments()
+                            do {
+                                if let lastReport = try await viewModel.fetchLastInventoryReport(propertyId: propertyId, leaseId: leaseId) {
+                                    isEntryInventory = lastReport.type == "end" || lastReport.type == "middle"
+                                } else {
+                                    isEntryInventory = true
+                                }
+                            } catch {
+                                errorMessage = "Error fetching inventory report: \(error.localizedDescription)".localized()
+                            }
+                        }
                     }
                 } catch {
-                    errorMessage = "Error fetching inventory report: \(error.localizedDescription)".localized()
+                    errorMessage = "Error fetching property data: \(error.localizedDescription)".localized()
                 }
-            } else {
-                isEntryInventory = true
+                isLoading = false
             }
-        } catch {
-            errorMessage = "Error fetching property data: \(error.localizedDescription)".localized()
         }
-        isLoading = false
     }
-    
+
     var body: some View {
         ZStack {
-            mainContentView
-            errorMessageView
-            
-            if selectedTab == "Damages".localized() && loginViewModel.userRole == "tenant" {
-                VStack {
-                    Spacer()
-                    HStack {
+            if let property = property {
+                mainContentView(property: property)
+                errorMessageView
+
+                if selectedTab == "Damages".localized() && loginViewModel.userRole == "tenant" && hasActiveLease {
+                    VStack {
                         Spacer()
-                        Button(action: { navigateToReportDamage = true }) {
-                            Image(systemName: "plus")
-                                .font(.system(size: 24, weight: .bold))
-                                .foregroundColor(.white)
-                                .padding()
-                                .background(Color("LightBlue"))
-                                .clipShape(Circle())
-                                .shadow(radius: 4)
+                        HStack {
+                            Spacer()
+                            Button(action: { navigateToReportDamage = true }) {
+                                Image(systemName: "plus")
+                                    .font(.system(size: 24, weight: .bold))
+                                    .foregroundColor(.white)
+                                    .padding()
+                                    .background(Color("LightBlue"))
+                                    .clipShape(Circle())
+                                    .shadow(radius: 4)
+                            }
+                            .accessibilityLabel("report_damage_btn")
                         }
-                        .accessibilityLabel("report_damage_btn")
                     }
+                    .padding(.bottom, 20)
+                    .padding(.trailing, 20)
                 }
-                .padding(.bottom, 20)
-                .padding(.trailing, 20)
+
+                if selectedTab == "Documents".localized() && (loginViewModel.userRole == "tenant" || loginViewModel.userRole == "owner") && hasActiveLease {
+                    VStack {
+                        Spacer()
+                        HStack {
+                            Spacer()
+                            Button(action: { showDocumentPicker = true }) {
+                                Image(systemName: "plus")
+                                    .font(.system(size: 24, weight: .bold))
+                                    .foregroundColor(.white)
+                                    .padding()
+                                    .background(Color("LightBlue"))
+                                    .clipShape(Circle())
+                                    .shadow(radius: 4)
+                            }
+                            .accessibilityLabel("upload_document_btn")
+                        }
+                    }
+                    .padding(.bottom, 20)
+                    .padding(.trailing, 20)
+                }
+            } else {
+                Text("Property not found".localized())
+                    .foregroundColor(.red)
+                    .padding()
             }
         }
         .navigationBarBackButtonHidden(true)
-        .onReceive(viewModel.$properties) { properties in
-            if let updatedProperty = properties.first(where: { $0.id == property.id }) {
-                if !updatedProperty.documents.isEmpty || updatedProperty.isAvailable != property.isAvailable {
-                    self.property = updatedProperty
-                }
-            }
-        }
         .onAppear {
             guard !hasLoaded else { return }
             hasLoaded = true
@@ -168,22 +218,74 @@ struct PropertyDetailView: View {
                 Task {
                     for _ in 1...3 {
                         await fetchDocuments()
-                        if !property.documents.isEmpty {
+                        if let property = property, !property.documents.isEmpty {
                             break
                         }
                         try? await Task.sleep(nanoseconds: 2_000_000_000)
                     }
-                    if property.documents.isEmpty {
+                    if let property = property, property.documents.isEmpty, hasActiveLease {
                         errorMessage = "No documents found after inventory finalization".localized()
                     }
                 }
             }
         }
         .sheet(isPresented: $showEditPropertyPopUp) {
-            EditPropertyView(viewModel: viewModel, property: $property)
+            if let property = property {
+                EditPropertyView(viewModel: viewModel, property: .constant(property))
+            }
         }
         .sheet(isPresented: $showInviteTenantSheet) {
-            InviteTenantView(tenantViewModel: tenantViewModel, property: property)
+            if let property = property {
+                InviteTenantView(tenantViewModel: tenantViewModel, property: property)
+            }
+        }
+        .sheet(isPresented: $showDocumentPicker) {
+            DocumentPicker { url in
+                Task {
+                    do {
+                        guard let propertyId = viewModel.properties.first(where: { $0.id == self.propertyId })?.id else {
+                            throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "No property selected.".localized()])
+                        }
+
+                        let allowedTypes: [UTType] = [.pdf, .init(filenameExtension: "docx")!, .init(filenameExtension: "xlsx")!]
+                        guard let fileType = UTType(filenameExtension: url.pathExtension.lowercased()),
+                              allowedTypes.contains(fileType) else {
+                            throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid file type. Only PDF, DOCX, and XLSX are supported.".localized()])
+                        }
+
+                        let mimeType: String
+                        switch fileType {
+                        case .pdf:
+                            mimeType = "application/pdf"
+                        case UTType(filenameExtension: "docx"):
+                            mimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                        case UTType(filenameExtension: "xlsx"):
+                            mimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                        default:
+                            mimeType = "application/octet-stream"
+                        }
+
+                        guard url.startAccessingSecurityScopedResource() else {
+                            throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Unable to access file.".localized()])
+                        }
+                        defer { url.stopAccessingSecurityScopedResource() }
+
+                        let data = try Data(contentsOf: url)
+                        let base64String = "data:\(mimeType);base64,\(data.base64EncodedString())"
+                        let fileName = url.lastPathComponent
+
+                        try await viewModel.uploadDocument(
+                            propertyId: propertyId,
+                            fileName: fileName,
+                            base64Data: base64String
+                        )
+
+                        await fetchDocuments()
+                    } catch {
+                        errorMessage = "Error uploading document: \(error.localizedDescription)".localized()
+                    }
+                }
+            }
         }
         .overlay(alertsView)
         .navigationDestination(isPresented: $navigateToInventory) {
@@ -191,50 +293,50 @@ struct PropertyDetailView: View {
                 .environmentObject(inventoryViewModel)
         }
         .navigationDestination(isPresented: $navigateToReportDamage) {
-            if activeLeaseId != nil {
+            if let _ = property, activeLeaseId != nil {
                 ReportDamageView(
                     viewModel: viewModel,
-                    propertyId: property.id,
+                    propertyId: propertyId,
                     rooms: rooms,
                     leaseId: activeLeaseId,
                     onDamageCreated: {
                         Task {
-                            try await viewModel.fetchPropertyDamages(propertyId: property.id, fixed: damageFilter)
-                            if let updatedProperty = viewModel.properties.first(where: { $0.id == property.id }) {
-                                property = updatedProperty
-                            }
+                            try await viewModel.fetchPropertyDamages(propertyId: propertyId, fixed: damageFilter)
                         }
                     }
                 )
             }
         }
     }
-    
+
     private var damagesContentView: some View {
         ZStack {
             VStack(spacing: 16) {
-                Picker("Filter Damages", selection: $damageFilter) {
-                    Text("In Progress".localized()).tag(false)
-                    Text("Fixed".localized()).tag(true)
-                }
-                .pickerStyle(.segmented)
-                .padding(.horizontal)
-                .onChange(of: damageFilter) {
-                    Task {
-                        do {
-                            try await viewModel.fetchPropertyDamages(propertyId: property.id, fixed: damageFilter)
-                            if let updatedProperty = viewModel.properties.first(where: { $0.id == property.id }) {
-                                property = updatedProperty
+                if hasActiveLease {
+                    Picker("Filter Damages", selection: $damageFilter) {
+                        Text("In Progress".localized()).tag(false as Bool?)
+                        Text("Fixed".localized()).tag(true as Bool?)
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(.horizontal)
+                    .onChange(of: damageFilter) {
+                        Task {
+                            do {
+                                try await viewModel.fetchPropertyDamages(propertyId: propertyId, fixed: damageFilter)
+                            } catch {
+                                errorMessage = "Error fetching damages: \(error.localizedDescription)".localized()
                             }
-                        } catch {
-                            errorMessage = "Error fetching damages: \(error.localizedDescription)".localized()
                         }
                     }
                 }
                 
                 ScrollView {
                     VStack(spacing: 16) {
-                        if viewModel.isFetchingDamages {
+                        if !hasActiveLease {
+                            Text("No lease is currently active".localized())
+                                .foregroundColor(.gray)
+                                .padding()
+                        } else if viewModel.isFetchingDamages {
                             ProgressView()
                                 .progressViewStyle(.circular)
                                 .padding()
@@ -242,16 +344,16 @@ struct PropertyDetailView: View {
                             Text(damagesError)
                                 .foregroundColor(.red)
                                 .padding()
-                        } else if let currentProperty = viewModel.properties.first(where: { $0.id == property.id }), !currentProperty.damages.isEmpty {
+                        } else if let property = property, !property.damages.isEmpty {
                             LazyVStack(spacing: 10) {
-                                ForEach(currentProperty.damages.sorted { $0.createdAt > $1.createdAt }, id: \.id) { damage in
+                                ForEach(property.damages.sorted { $0.createdAt > $1.createdAt }, id: \.id) { damage in
                                     DamageItemView(damage: damage, selectedDamageId: $selectedDamageId)
                                         .id(damage.id)
                                 }
                             }
                             .padding(.horizontal)
                         } else {
-                            Text("no_damages_reported".localized())
+                            Text("No damages reported".localized())
                                 .foregroundColor(.gray)
                                 .padding()
                         }
@@ -265,40 +367,37 @@ struct PropertyDetailView: View {
             set: { if !$0 { selectedDamageId = nil } }
         )) {
             if let damageId = selectedDamageId,
-               let damage = viewModel.properties
-                   .first(where: { $0.id == property.id })?
-                   .damages
-                   .first(where: { $0.id == damageId }) {
+               let damage = property?.damages.first(where: { $0.id == damageId }) {
                 DamageDetailView(damage: damage)
             }
         }
     }
-
-    private var mainContentView: some View {
+    
+    private func mainContentView(property: Property) -> some View {
         VStack(spacing: 0) {
             TopBar(title: "Keyz".localized())
-            headerView
+            headerView(property: property)
             tabsView
-            contentScrollView
+            contentScrollView(property: property)
         }
     }
 
-    private var headerView: some View {
+    private func headerView(property: Property) -> some View {
         VStack(alignment: .leading, spacing: 16) {
             ZStack(alignment: .topLeading) {
-                imageView
+                imageView(property: property)
                 if loginViewModel.userRole == "owner" {
                     backButtonView
-                    optionsMenuView
+                    optionsMenuView(property: property)
                 }
             }
-            propertyInfoView
+            propertyInfoView(property: property)
         }
     }
 
-    private var imageView: some View {
+    private func imageView(property: Property) -> some View {
         Group {
-            if isLoading {
+            if isImageLoading {
                 VStack {
                     Spacer()
                     ProgressView()
@@ -338,7 +437,7 @@ struct PropertyDetailView: View {
         .accessibilityLabel("back_button")
     }
 
-    private var optionsMenuView: some View {
+    private func optionsMenuView(property: Property) -> some View {
         Menu {
             if property.isAvailable == "available" {
                 Button(action: { showInviteTenantSheet = true }) {
@@ -374,14 +473,14 @@ struct PropertyDetailView: View {
         .accessibilityLabel("options_button")
     }
 
-    private var propertyInfoView: some View {
+    private func propertyInfoView(property: Property) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Text(property.name)
                     .font(.title2)
                     .fontWeight(.bold)
                     .foregroundColor(Color("textColor"))
-                Text(statusText)
+                Text(statusText(property: property))
                     .font(.caption)
                     .fontWeight(.medium)
                     .foregroundColor(.white)
@@ -389,9 +488,9 @@ struct PropertyDetailView: View {
                     .padding(.vertical, 4)
                     .background(
                         RoundedRectangle(cornerRadius: 8)
-                            .fill(statusColor)
+                            .fill(statusColor(property: property))
                     )
-                    .accessibilityLabel(statusAccessibilityLabel)
+                    .accessibilityLabel(statusAccessibilityLabel(property: property))
             }
             HStack(spacing: 4) {
                 Image(systemName: "mappin.and.ellipse.circle")
@@ -408,7 +507,7 @@ struct PropertyDetailView: View {
         .padding(.bottom, 8)
     }
 
-    private var statusText: String {
+    private func statusText(property: Property) -> String {
         switch property.isAvailable {
         case "available": return "Available".localized()
         case "pending": return "Pending".localized()
@@ -417,7 +516,7 @@ struct PropertyDetailView: View {
         }
     }
 
-    private var statusColor: Color {
+    private func statusColor(property: Property) -> Color {
         switch property.isAvailable {
         case "available": return Color("GreenAlert")
         case "pending": return Color.orange
@@ -426,7 +525,7 @@ struct PropertyDetailView: View {
         }
     }
 
-    private var statusAccessibilityLabel: String {
+    private func statusAccessibilityLabel(property: Property) -> String {
         switch property.isAvailable {
         case "available": return "text_available"
         case "pending": return "text_pending"
@@ -468,20 +567,24 @@ struct PropertyDetailView: View {
         .shadow(color: Color.black.opacity(0.1), radius: 6, x: 0, y: 8)
     }
 
-    private var contentScrollView: some View {
+    private func contentScrollView(property: Property) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 switch selectedTab {
                 case "Details".localized():
-                    detailsContentView
-                    actionButtonView
+                    detailsContentView(property: property)
+                    actionButtonView(property: property)
                 case "Documents".localized():
                     if let errorMessage = errorMessage {
                         Text(errorMessage)
                             .foregroundColor(.red)
                             .padding()
+                    } else if !hasActiveLease {
+                        Text("No lease is currently active".localized())
+                            .foregroundColor(.gray)
+                            .padding()
                     } else {
-                        DocumentsGridView(documents: $property.documents)
+                        DocumentsGridView(documents: .constant(property.documents))
                             .padding(.horizontal)
                     }
                 case "Damages".localized():
@@ -494,7 +597,7 @@ struct PropertyDetailView: View {
         }
     }
 
-    private var detailsContentView: some View {
+    private func detailsContentView(property: Property) -> some View {
         VStack(alignment: .leading, spacing: 16) {
             LazyVGrid(
                 columns: Array(repeating: GridItem(.flexible(), spacing: 15), count: 3),
@@ -531,14 +634,14 @@ struct PropertyDetailView: View {
                 Text("Dates".localized())
                     .font(.headline)
                     .foregroundColor(Color("textColor"))
-                Text(formatLeaseDates())
+                Text(formatLeaseDates(property: property))
                     .foregroundColor(.gray)
             }
             .padding(.horizontal)
         }
     }
 
-    private var actionButtonView: some View {
+    private func actionButtonView(property: Property) -> some View {
         VStack {
             Group {
                 if loginViewModel.userRole == "owner" {
@@ -589,11 +692,8 @@ struct PropertyDetailView: View {
                         Task {
                             do {
                                 let token = try await TokenStorage.getValidAccessToken()
-                                try await viewModel.cancelInvite(propertyId: property.id, token: token)
+                                try await viewModel.cancelInvite(propertyId: propertyId, token: token)
                                 await viewModel.fetchProperties()
-                                if let updatedProperty = viewModel.properties.first(where: { $0.id == property.id }) {
-                                    property = updatedProperty
-                                }
                             } catch {
                                 errorMessage = "Error cancelling invite: \(error.localizedDescription)".localized()
                             }
@@ -614,12 +714,9 @@ struct PropertyDetailView: View {
                         Task {
                             do {
                                 let token = try await TokenStorage.getValidAccessToken()
-                                if let leaseId = try await viewModel.fetchActiveLease(propertyId: property.id, token: token) {
-                                    try await viewModel.endLease(propertyId: property.id, leaseId: leaseId, token: token)
+                                if let leaseId = try await viewModel.fetchActiveLease(propertyId: propertyId, token: token) {
+                                    try await viewModel.endLease(propertyId: propertyId, leaseId: leaseId, token: token)
                                     await viewModel.fetchProperties()
-                                    if let updatedProperty = viewModel.properties.first(where: { $0.id == property.id }) {
-                                        property = updatedProperty
-                                    }
                                 } else {
                                     errorMessage = "No active lease found.".localized()
                                 }
@@ -642,7 +739,7 @@ struct PropertyDetailView: View {
                     action: {
                         Task {
                             do {
-                                try await viewModel.deleteProperty(propertyId: property.id)
+                                try await viewModel.deleteProperty(propertyId: propertyId)
                                 dismiss()
                             } catch {
                                 errorMessage = "Error deleting property: \(error.localizedDescription)".localized()
@@ -660,7 +757,7 @@ struct PropertyDetailView: View {
         value == Double(Int(value)) ? String(format: "%.0f", value) : String(format: "%.2f", value)
     }
 
-    private func formatLeaseDates() -> String {
+    private func formatLeaseDates(property: Property) -> String {
         if property.leaseStartDate == nil && property.leaseEndDate == nil {
             return "No active lease".localized()
         }
@@ -704,7 +801,7 @@ struct PropertyDetailView_Previews: PreviewProvider {
     
     static var previews: some View {
         let property = Property(
-            id: "",
+            id: "property_001",
             ownerID: "",
             name: "Condo",
             address: "4391 Hedge Street",
@@ -743,7 +840,7 @@ struct PropertyDetailView_Previews: PreviewProvider {
                     fixPlannedAt: "2025-05-25T14:00:00Z",
                     fixedAt: nil,
                     leaseId: "lease_001",
-                    propertyId: "",
+                    propertyId: "property_001",
                     propertyName: "Condo",
                     tenantName: "John & Mary Doe",
                     read: true
@@ -760,7 +857,7 @@ struct PropertyDetailView_Previews: PreviewProvider {
                     fixPlannedAt: nil,
                     fixedAt: "2025-05-18T15:00:00Z",
                     leaseId: "lease_001",
-                    propertyId: "",
+                    propertyId: "property_001",
                     propertyName: "Condo",
                     tenantName: "John & Mary Doe",
                     read: false
@@ -777,7 +874,7 @@ struct PropertyDetailView_Previews: PreviewProvider {
                     fixPlannedAt: nil,
                     fixedAt: nil,
                     leaseId: "lease_001",
-                    propertyId: "",
+                    propertyId: "property_001",
                     propertyName: "Condo",
                     tenantName: "John & Mary Doe",
                     read: true
@@ -794,7 +891,7 @@ struct PropertyDetailView_Previews: PreviewProvider {
                     fixPlannedAt: nil,
                     fixedAt: nil,
                     leaseId: "lease_001",
-                    propertyId: "",
+                    propertyId: "property_001",
                     propertyName: "Condo",
                     tenantName: "John & Mary Doe",
                     read: true
@@ -804,9 +901,10 @@ struct PropertyDetailView_Previews: PreviewProvider {
         
         let viewModel = PropertyViewModel(loginViewModel: LoginViewModel())
         let loginViewModel = LoginViewModel()
+        viewModel.properties = [property]
         
         return PropertyDetailView(
-            property: property,
+            propertyId: "property_001",
             viewModel: viewModel,
             navigateToReportDamage: $navigateToReportDamage,
             navigateToInventory: $navigateToInventory

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyView.swift
@@ -15,7 +15,7 @@ struct PropertyView: View {
     @State private var errorMessage: String?
     @State private var navigateToReportDamage: Bool = false
     @State private var navigateToInventory: Bool = false
-    @State private var selectedProperty: Property?
+    @State private var selectedPropertyId: String?
 
     var body: some View {
         NavigationStack {
@@ -29,11 +29,12 @@ struct PropertyView: View {
                     }
                 } else if let property = tenantProperty {
                     PropertyDetailView(
-                        property: property,
+                        propertyId: property.id,
                         viewModel: viewModel,
                         navigateToReportDamage: $navigateToReportDamage,
                         navigateToInventory: $navigateToInventory
-                    )                } else {
+                    )
+                } else {
                     VStack {
                         Spacer()
                         Text("No property associated.".localized())
@@ -71,7 +72,7 @@ struct PropertyView: View {
                                     ForEach(viewModel.properties) { property in
                                         NavigationLink(
                                             destination: PropertyDetailView(
-                                                property: property,
+                                                propertyId: property.id,
                                                 viewModel: viewModel,
                                                 navigateToReportDamage: $navigateToReportDamage,
                                                 navigateToInventory: $navigateToInventory
@@ -81,7 +82,7 @@ struct PropertyView: View {
                                             PropertyCard(property: property)
                                         }
                                         .simultaneousGesture(TapGesture().onEnded {
-                                            selectedProperty = property
+                                            selectedPropertyId = property.id
                                         })
                                     }
                                 }
@@ -116,16 +117,17 @@ struct PropertyView: View {
                     }
                 }
                 .navigationDestination(isPresented: $navigateToReportDamage) {
-                    if let property = selectedProperty {
+                    if let propertyId = selectedPropertyId,
+                       let property = viewModel.properties.first(where: { $0.id == propertyId }) {
                         ReportDamageView(
                             viewModel: viewModel,
-                            propertyId: property.id,
+                            propertyId: propertyId,
                             rooms: [],
                             leaseId: viewModel.activeLeaseId,
                             onDamageCreated: {
                                 Task {
                                     do {
-                                        try await viewModel.fetchPropertyDamages(propertyId: property.id)
+                                        try await viewModel.fetchPropertyDamages(propertyId: propertyId)
                                     } catch {
                                         errorMessage = "Error refreshing damages: \(error.localizedDescription)".localized()
                                     }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyViewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyViewModel.swift
@@ -220,6 +220,30 @@ class PropertyViewModel: ObservableObject {
             try await ownerViewModel.fixDamage(propertyId: propertyId, damageId: damageId, token: token)
         }
     }
+    
+    func uploadOwnerDocument(propertyId: String, fileName: String, base64Data: String) async throws {
+        guard storedUserRole == "owner" else {
+            throw NSError(domain: "", code: 403, userInfo: [NSLocalizedDescriptionKey: "Only owners can upload owner documents.".localized()])
+        }
+        try await ownerViewModel.uploadOwnerDocument(propertyId: propertyId, fileName: fileName, base64Data: base64Data)
+    }
+
+    func uploadTenantDocument(leaseId: String, propertyId: String, fileName: String, base64Data: String) async throws {
+        guard storedUserRole == "tenant" else {
+            throw NSError(domain: "", code: 403, userInfo: [NSLocalizedDescriptionKey: "Only tenants can upload tenant documents.".localized()])
+        }
+        try await tenantViewModel.uploadTenantDocument(leaseId: leaseId, propertyId: propertyId, fileName: fileName, base64Data: base64Data)
+    }
+
+    func deleteDocument(docId: String) async throws {
+        guard storedUserRole == "owner" else {
+            throw NSError(domain: "", code: 403, userInfo: [NSLocalizedDescriptionKey: "Only owners can delete documents.".localized()])
+        }
+        guard let property = properties.first(where: { $0.documents.contains(where: { $0.id == docId }) }) else {
+            throw NSError(domain: "", code: 404, userInfo: [NSLocalizedDescriptionKey: "Document not found.".localized()])
+        }
+        try await ownerViewModel.deleteDocument(propertyId: property.id, documentId: docId)
+    }
 }
 
 struct PropertyID: Decodable {

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/SubViews/DocumentsGridView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/SubViews/DocumentsGridView.swift
@@ -17,6 +17,7 @@ struct DocumentsGridView: View {
     @State private var refreshID = UUID()
     @State private var isInitialized = false
     @State private var errorMessage: String?
+    var onDelete: ((String) -> Void)?
 
     var body: some View {
         VStack {
@@ -36,21 +37,42 @@ struct DocumentsGridView: View {
                     spacing: 15
                 ) {
                     ForEach(documents, id: \.id) { document in
-                        NavigationLink(destination: PDFViewer(base64String: document.data)) {
-                            VStack {
-                                Image(systemName: "doc.text")
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 50, height: 50)
-                                Text(document.title)
-                                    .font(.caption)
-                                    .multilineTextAlignment(.center)
-                                    .frame(maxWidth: .infinity)
+                        ZStack(alignment: .topTrailing) {
+                            NavigationLink(destination: PDFViewer(base64String: document.data)) {
+                                VStack {
+                                    Image(systemName: "doc.text")
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(width: 50, height: 50)
+                                    Text(document.title)
+                                        .font(.caption)
+                                        .multilineTextAlignment(.center)
+                                        .frame(maxWidth: .infinity)
+                                }
+                                .padding()
+                                .frame(maxWidth: .infinity)
+                                .background(Color.gray.opacity(0.1))
+                                .cornerRadius(8)
                             }
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                            .background(Color.gray.opacity(0.1))
-                            .cornerRadius(8)
+                            
+                            if loginViewModel.userRole == "owner" {
+                                Menu {
+                                    Button(role: .destructive) {
+                                        onDelete?(document.id)
+                                    } label: {
+                                        Label("Delete".localized(), systemImage: "trash")
+                                    }
+                                } label: {
+                                    Image(systemName: "ellipsis")
+                                        .font(.caption)
+                                        .foregroundColor(.gray)
+                                        .padding(6)
+                                        .background(Color.white.opacity(0.8))
+                                        .clipShape(Circle())
+                                }
+                                .padding([.top, .trailing], 4)
+                                .accessibilityLabel("document_options_\(document.id)")
+                            }
                         }
                     }
                 }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/SubViews/DocumentsGridView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/SubViews/DocumentsGridView.swift
@@ -7,14 +7,25 @@
 
 import SwiftUI
 import PDFKit
+import UniformTypeIdentifiers
+import MobileCoreServices
 
 struct DocumentsGridView: View {
     @Binding var documents: [PropertyDocument]
+    @EnvironmentObject var propertyViewModel: PropertyViewModel
+    @EnvironmentObject var loginViewModel: LoginViewModel
     @State private var refreshID = UUID()
     @State private var isInitialized = false
+    @State private var errorMessage: String?
 
     var body: some View {
         VStack {
+            if let errorMessage = errorMessage {
+                Text(errorMessage)
+                    .foregroundColor(.red)
+                    .padding()
+            }
+            
             if documents.isEmpty {
                 Text("No documents available".localized())
                     .foregroundColor(.gray)
@@ -54,12 +65,92 @@ struct DocumentsGridView: View {
             isInitialized = true
         }
     }
+    
+    private func handleDocumentSelection(url: URL) async throws {
+        guard let propertyId = propertyViewModel.properties.first?.id else {
+            throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "No property selected.".localized()])
+        }
+        
+        let allowedTypes: [UTType] = [.pdf, .init(filenameExtension: "docx")!, .init(filenameExtension: "xlsx")!]
+        guard let fileType = UTType(filenameExtension: url.pathExtension.lowercased()),
+              allowedTypes.contains(fileType) else {
+            throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid file type. Only PDF, DOCX, and XLSX are supported.".localized()])
+        }
+        
+        let mimeType: String
+        switch fileType {
+        case .pdf:
+            mimeType = "application/pdf"
+        case UTType(filenameExtension: "docx"):
+            mimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        case UTType(filenameExtension: "xlsx"):
+            mimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        default:
+            mimeType = "application/octet-stream"
+        }
+        
+        guard url.startAccessingSecurityScopedResource() else {
+            throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Unable to access file.".localized()])
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+        
+        let data = try Data(contentsOf: url)
+        let base64String = "data:\(mimeType);base64,\(data.base64EncodedString())"
+        let fileName = url.lastPathComponent
+        
+        try await propertyViewModel.uploadDocument(
+            propertyId: propertyId,
+            fileName: fileName,
+            base64Data: base64String
+        )
+        
+        let updatedDocuments = try await propertyViewModel.fetchPropertyDocuments(propertyId: propertyId)
+        documents = updatedDocuments
+    }
+}
+
+struct DocumentPicker: UIViewControllerRepresentable {
+    var onDocumentPicked: (URL) -> Void
+    
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [
+            .pdf,
+            UTType(filenameExtension: "docx") ?? .data,
+            UTType(filenameExtension: "xlsx") ?? .data
+        ])
+        picker.delegate = context.coordinator
+        return picker
+    }
+    
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let parent: DocumentPicker
+        
+        init(_ parent: DocumentPicker) {
+            self.parent = parent
+        }
+        
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            if let url = urls.first {
+                parent.onDocumentPicked(url)
+            }
+        }
+        
+        func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {}
+    }
 }
 
 struct DocumentsGridView_Previews: PreviewProvider {
     static var previews: some View {
         DocumentsGridView(documents: .constant([
-            PropertyDocument(id: "doc1", title: "Lease Agreement", fileName: "test", data: "base64_data")
+            PropertyDocument(id: "doc1", title: "Lease Agreement", fileName: "test.pdf", data: "base64_data")
         ]))
+        .environmentObject(PropertyViewModel(loginViewModel: LoginViewModel()))
+        .environmentObject(LoginViewModel())
     }
 }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/ViewModels/TenantPropertyViewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/ViewModels/TenantPropertyViewModel.swift
@@ -159,61 +159,52 @@ class TenantPropertyViewModel: ObservableObject {
     }
     
     func fetchPropertiesPicture(propertyId: String) async throws -> UIImage? {
+        if let cachedImage = ImageCache.shared.getImage(forKey: propertyId) {
+            return cachedImage
+        }
+
         let url = URL(string: "\(APIConfig.baseURL)/tenant/leases/current/property/picture/")!
         var attemptCount = 0
         let maxAttempts = 2
-        
+
         while attemptCount < maxAttempts {
             attemptCount += 1
             do {
                 let token = try await TokenStorage.getValidAccessToken()
-                
                 var urlRequest = URLRequest(url: url)
                 urlRequest.httpMethod = "GET"
                 urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
                 urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-                
+
                 let (data, response) = try await URLSession.shared.data(for: urlRequest)
-                
                 guard let httpResponse = response as? HTTPURLResponse else {
                     throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid response from server.".localized()])
                 }
-                
+
                 switch httpResponse.statusCode {
                 case 200, 201:
-                    do {
-                        let propertyImage = try JSONDecoder().decode(PropertyImageBase64.self, from: data)
-                        
-                        var base64String = propertyImage.data
-                        if base64String.contains(",") {
-                            base64String = base64String.components(separatedBy: ",").last ?? base64String
-                        }
-                        
-                        guard let imageData = Data(base64Encoded: base64String, options: [.ignoreUnknownCharacters]) else {
-                            throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to decode base64 data.".localized()])
-                        }
-                        guard let image = UIImage(data: imageData) else {
-                            throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to create image from data.".localized()])
-                        }
-                        return image
-                    } catch {
-                        throw error
+                    let propertyImage = try JSONDecoder().decode(PropertyImageBase64.self, from: data)
+                    var base64String = propertyImage.data
+                    if base64String.contains(",") {
+                        base64String = base64String.components(separatedBy: ",").last ?? base64String
                     }
-                case 204:
+                    guard let imageData = Data(base64Encoded: base64String, options: [.ignoreUnknownCharacters]),
+                          let image = UIImage(data: imageData) else {
+                        throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to decode image.".localized()])
+                    }
+                    ImageCache.shared.setImage(image, forKey: propertyId)
+                    return image
+                case 204, 403, 404:
+                    ImageCache.shared.setImage(nil, forKey: propertyId)
                     return nil
                 case 401:
                     if attemptCount == maxAttempts {
                         throw NSError(domain: "", code: 401, userInfo: [NSLocalizedDescriptionKey: "Unauthorized after \(maxAttempts) attempts.".localized()])
                     }
                     continue
-                case 403:
-                    return nil
-                case 404:
-                    return nil
                 default:
                     let errorBody = String(data: data, encoding: .utf8) ?? "No error details"
-                    throw NSError(domain: "", code: httpResponse.statusCode,
-                                  userInfo: [NSLocalizedDescriptionKey: "Failed with status code: \(httpResponse.statusCode) - \(errorBody)"])
+                    throw NSError(domain: "", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: "Failed with status code: \(httpResponse.statusCode) - \(errorBody)".localized()])
                 }
             } catch {
                 if attemptCount == maxAttempts {
@@ -556,6 +547,51 @@ class TenantPropertyViewModel: ObservableObject {
                               userInfo: [NSLocalizedDescriptionKey: "Failed with status code: \(httpResponse.statusCode) - \(errorBody)".localized()])
             }
         }
+    }
+    
+    func uploadTenantDocument(leaseId: String, propertyId: String, fileName: String, base64Data: String) async throws {
+        let url = URL(string: "\(APIConfig.baseURL)/tenant/properties/\(propertyId)/leases/\(leaseId)/docs/")!
+        let token = try await TokenStorage.getValidAccessToken()
+        
+        let body: [String: Any] = [
+            "name": fileName,
+            "data": base64Data
+        ]
+        
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        
+        let jsonData = try JSONSerialization.data(withJSONObject: body)
+        urlRequest.httpBody = jsonData
+        
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid response from server.".localized()])
+        }
+        
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "No error details"
+            switch httpResponse.statusCode {
+            case 400:
+                throw NSError(domain: "", code: 400, userInfo: [NSLocalizedDescriptionKey: "Invalid document data: \(errorBody)".localized()])
+            case 401:
+                throw NSError(domain: "", code: 401, userInfo: [NSLocalizedDescriptionKey: "Unauthorized. Please check your token.".localized()])
+            case 403:
+                throw NSError(domain: "", code: 403, userInfo: [NSLocalizedDescriptionKey: "Lease not yours.".localized()])
+            case 404:
+                throw NSError(domain: "", code: 404, userInfo: [NSLocalizedDescriptionKey: "Property or lease not found.".localized()])
+            default:
+                throw NSError(domain: "", code: httpResponse.statusCode,
+                              userInfo: [NSLocalizedDescriptionKey: "Failed with status code: \(httpResponse.statusCode) - \(errorBody)".localized()])
+            }
+        }
+        
+        let decoder = JSONDecoder()
+        let _ = try decoder.decode(IdResponse.self, from: data)
     }
 }
 


### PR DESCRIPTION
Main change:
- Enabled document upload (PDF, DOCX, XLSX) for owners and tenants with role-based access.
- Added document deletion for owners with a confirmation alert.

Other:
- Optimized APi calls, especially those retrieving pictures by adding an ImageCache



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for uploading and deleting property documents, with file type validation and role-based access for owners and tenants.
  - Introduced image caching for property photos to improve performance and reduce redundant downloads.
  - Added document picker for selecting and uploading PDF, DOCX, and XLSX files.
  - Added confirmation popup for document deletion.

- **Enhancements**
  - Improved error handling and user feedback during document and image operations.
  - Updated navigation to use property IDs instead of full property objects, streamlining data flow and UI updates.
  - Refined UI prompts to better reflect room status selection.

- **Bug Fixes**
  - Ensured image cache is invalidated when property photos are updated to prevent display of outdated images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->