### PR TITLE
Fix/ios app end lease

### DIFF
--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/InviteTenantView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/InviteTenantView.swift
@@ -116,6 +116,7 @@ struct InviteTenantView: View {
                         displayedComponents: [.date]
                     )
                     .datePickerStyle(.graphical)
+                    .accentColor(Color("LightBlue"))
                     .padding()
                     
                     Button("Done".localized()) {
@@ -124,9 +125,9 @@ struct InviteTenantView: View {
                     .font(.headline)
                     .foregroundColor(.white)
                     .padding()
-                    .background(Color.blue)
+                    .background(Color("LightBlue"))
                     .clipShape(RoundedRectangle(cornerRadius: 10))
-                    .padding(.bottom)
+                    .padding(.bottom, 70)
                 }
                 .presentationDetents([.medium])
                 .presentationDragIndicator(.visible)
@@ -152,6 +153,7 @@ struct InviteTenantView: View {
                         displayedComponents: [.date]
                     )
                     .datePickerStyle(.graphical)
+                    .accentColor(Color("LightBlue"))
 
                     HStack {
                         Button("Reset".localized()) {
@@ -160,7 +162,7 @@ struct InviteTenantView: View {
                             showEndDatePicker = false
                         }
                         .font(.headline)
-                        .foregroundColor(.red)
+                        .foregroundColor(Color("RedAlert"))
                         .padding()
                         .disabled(endDate == nil)
                                                 
@@ -173,10 +175,10 @@ struct InviteTenantView: View {
                         .font(.headline)
                         .foregroundColor(.white)
                         .padding()
-                        .background(Color.blue)
+                        .background(Color("LightBlue"))
                         .clipShape(RoundedRectangle(cornerRadius: 10))
                     }
-                    .padding(.bottom)
+                    .padding(.bottom, 50)
                 }
                 .presentationDetents([.medium])
                 .presentationDragIndicator(.visible)

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/InviteTenantView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/InviteTenantView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct InviteTenantView: View {
     @ObservedObject var tenantViewModel: TenantViewModel
+    @ObservedObject var propertyViewModel: PropertyViewModel
     let property: Property
     @State private var email: String = ""
     @State private var startDate: Date = Date()
@@ -58,6 +59,7 @@ struct InviteTenantView: View {
                                 startDate: startDate,
                                 endDate: endDate
                             )
+                            await propertyViewModel.fetchProperties()
                             dismiss()
                         } catch {
                             print("Error inviting tenant: \(error)".localized())
@@ -80,9 +82,11 @@ struct InviteTenantView: View {
 
 struct InviteTenantView_Previews: PreviewProvider {
     static var viewModel = TenantViewModel()
+    static var propViewModel = PropertyViewModel(loginViewModel: LoginViewModel())
     static var previews: some View {
         InviteTenantView(
             tenantViewModel: viewModel,
+            propertyViewModel: propViewModel,
             property: exampleDataProperty
         )
     }

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/InviteTenantView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/InviteTenantView.swift
@@ -14,7 +14,18 @@ struct InviteTenantView: View {
     @State private var email: String = ""
     @State private var startDate: Date = Date()
     @State private var endDate: Date? = nil
+    @State private var showStartDatePicker: Bool = false
+    @State private var showEndDatePicker: Bool = false
+    @State private var tempEndDate: Date? = nil
+    @State private var didCancelEndDate: Bool = false
     @Environment(\.dismiss) var dismiss
+    
+    private var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }
     
     var body: some View {
         NavigationStack {
@@ -24,30 +35,41 @@ struct InviteTenantView: View {
                         .keyboardType(.emailAddress)
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
-                
-                    DatePicker("Start Date".localized(),
-                              selection: $startDate,
-                              displayedComponents: .date)
-                        .datePickerStyle(.compact)
                     
-                    DatePicker("End Date (Optional)".localized(),
-                              selection: Binding(
-                                get: { endDate ?? Date() },
-                                set: { endDate = $0 }
-                              ),
-                              displayedComponents: .date)
-                        .datePickerStyle(.compact)
-                        .foregroundColor(endDate == nil ? .gray : .primary)
-                        .overlay(
-                            Button(action: {
-                                endDate = nil
-                            }) {
-                                Image(systemName: "xmark.circle.fill")
+                    HStack {
+                        Button(action: {
+                            showStartDatePicker = true
+                        }) {
+                            HStack {
+                                Text("Start Date".localized())
+                                    .foregroundColor(.primary)
+                                Spacer()
+                                Text(dateFormatter.string(from: startDate))
                                     .foregroundColor(.gray)
                             }
-                            .opacity(endDate != nil ? 1 : 0),
-                            alignment: .trailing
-                        )
+                            .padding(.vertical, 8)
+                            .contentShape(Rectangle())
+                        }
+                        .accessibilityLabel("Select Start Date")
+                    }
+                    
+                    HStack {
+                        Button(action: {
+                            tempEndDate = endDate
+                            showEndDatePicker = true
+                        }) {
+                            HStack {
+                                Text("End Date (Optional)".localized())
+                                    .foregroundColor(endDate == nil ? .gray : .primary)
+                                Spacer()
+                                Text(endDate.map { dateFormatter.string(from: $0) } ?? "Not Set")
+                                    .foregroundColor(.gray)
+                            }
+                            .padding(.vertical, 8)
+                            .contentShape(Rectangle())
+                        }
+                        .accessibilityLabel("Select End Date")
+                    }
                 }
                 
                 Button("Send Invitation".localized()) {
@@ -62,7 +84,7 @@ struct InviteTenantView: View {
                             await propertyViewModel.fetchProperties()
                             dismiss()
                         } catch {
-                            print("Error inviting tenant: \(error)".localized())
+                            print("Error inviting tenant: \(error.localizedDescription)".localized())
                         }
                     }
                 }
@@ -75,6 +97,89 @@ struct InviteTenantView: View {
                         dismiss()
                     }
                 }
+            }
+            .onChange(of: startDate) {
+                if let currentEndDate = endDate, startDate > currentEndDate {
+                    endDate = nil
+                }
+            }
+            .sheet(isPresented: $showStartDatePicker) {
+                VStack {
+                    Text("Select Start Date".localized())
+                        .font(.headline)
+                        .padding()
+                    
+                    DatePicker(
+                        "Start Date".localized(),
+                        selection: $startDate,
+                        in: Date()...,
+                        displayedComponents: [.date]
+                    )
+                    .datePickerStyle(.graphical)
+                    .padding()
+                    
+                    Button("Done".localized()) {
+                        showStartDatePicker = false
+                    }
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .padding()
+                    .background(Color.blue)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .padding(.bottom)
+                }
+                .presentationDetents([.medium])
+                .presentationDragIndicator(.visible)
+            }
+            .sheet(isPresented: $showEndDatePicker, onDismiss: {
+                if !didCancelEndDate, let selected = tempEndDate, selected >= startDate {
+                    endDate = selected
+                }
+                didCancelEndDate = false
+            }) {
+                VStack {
+                    Text("Select End Date".localized())
+                        .font(.headline)
+                        .padding()
+                    
+                    DatePicker(
+                        "End Date".localized(),
+                        selection: Binding(
+                            get: { endDate ?? max(startDate, Date()) },
+                            set: { endDate = $0 }
+                        ),
+                        in: startDate...,
+                        displayedComponents: [.date]
+                    )
+                    .datePickerStyle(.graphical)
+
+                    HStack {
+                        Button("Reset".localized()) {
+                            endDate = nil
+                            tempEndDate = nil
+                            showEndDatePicker = false
+                        }
+                        .font(.headline)
+                        .foregroundColor(.red)
+                        .padding()
+                        .disabled(endDate == nil)
+                                                
+                        Button("Done".localized()) {
+                            if let newEndDate = tempEndDate, newEndDate >= startDate {
+                                endDate = newEndDate
+                            }
+                            showEndDatePicker = false
+                        }
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .padding()
+                        .background(Color.blue)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                    }
+                    .padding(.bottom)
+                }
+                .presentationDetents([.medium])
+                .presentationDragIndicator(.visible)
             }
         }
     }
@@ -91,4 +196,3 @@ struct InviteTenantView_Previews: PreviewProvider {
         )
     }
 }
-

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyDetailView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyDetailView.swift
@@ -238,7 +238,11 @@ struct PropertyDetailView: View {
         }
         .sheet(isPresented: $showInviteTenantSheet) {
             if let property = property {
-                InviteTenantView(tenantViewModel: tenantViewModel, property: property)
+                InviteTenantView(
+                    tenantViewModel: tenantViewModel,
+                    propertyViewModel: viewModel,
+                    property: property
+                )
             }
         }
         .sheet(isPresented: $showDocumentPicker) {

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyView.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/PropertyView.swift
@@ -118,7 +118,7 @@ struct PropertyView: View {
                 }
                 .navigationDestination(isPresented: $navigateToReportDamage) {
                     if let propertyId = selectedPropertyId,
-                       let property = viewModel.properties.first(where: { $0.id == propertyId }) {
+                       let _ = viewModel.properties.first(where: { $0.id == propertyId }) {
                         ReportDamageView(
                             viewModel: viewModel,
                             propertyId: propertyId,

--- a/Code/Mobile_iOS/Keyz/Sources/Views/Property/ViewModels/OwnerPropertyViewModel.swift
+++ b/Code/Mobile_iOS/Keyz/Sources/Views/Property/ViewModels/OwnerPropertyViewModel.swift
@@ -446,11 +446,8 @@ class OwnerPropertyViewModel: ObservableObject {
         urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
         
-        debugPrintAPIRequest(urlRequest)
-        
         let (data, response) = try await URLSession.shared.data(for: urlRequest)
         
-        debugPrintAPIResponse(data, response: response, error: nil)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid response from server.".localized()])
         }


### PR DESCRIPTION
Fixed end lease not taking end date -> resulted in an error in decoding part

PropertyDetailView is now refreshing directly after invitation of a new tenant

Changed calendars in InviteTenantView -> UI purposes + bug fix (clear button under date, not clickable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved date selection in the tenant invitation process with modal graphical date pickers for start and end dates, including options to reset, cancel, or confirm end date selection.
  - Dates are now consistently displayed in a localized format.

- **Bug Fixes**
  - End date selection now prevents choosing a date earlier than the start date.

- **Improvements**
  - Tenant invitation now refreshes property data automatically after sending an invite.
  - Enhanced lease handling to better identify active leases and support multiple date formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->